### PR TITLE
Initialize PCU tracker

### DIFF
--- a/pkg/controller/mytype/mytype.go
+++ b/pkg/controller/mytype/mytype.go
@@ -58,7 +58,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 
 	r := managed.NewReconciler(mgr,
 		resource.ManagedKind(v1alpha1.MyTypeGroupVersionKind),
-		managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newServiceFn: newNoOpService}),
+		managed.WithExternalConnecter(&connector{
+			kube:         mgr.GetClient(),
+			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
+			newServiceFn: newNoOpService}),
 		managed.WithInitializers(managed.NewNameAsExternalName(mgr.GetClient())),
 		managed.WithLogger(l.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))


### PR DESCRIPTION
The PCU tracker was added and setup to track the provider's PCU, but it
was not initialized during reconciler creation.

Fixes #7 

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>