### PR TITLE
Add OWNERS.md file with repo maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,14 @@
+# OWNERS
+
+This page lists all maintainers for **this** repository. Each repository in the [Crossplane
+organization](https://github.com/crossplane/) will list their repository maintainers in their own
+`OWNERS.md` file.
+
+Please see the Crossplane
+[GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md) for governance
+guidelines and responsibilities for the steering committee and maintainers.
+
+## Maintainers
+
+* Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
+* Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))


### PR DESCRIPTION
This PR adds the OWNERS.md files that includes the current maintainers for this repository.

Fixes #9 