### PR TITLE
Update to latest crossplane-runtime and new ProviderConfig structure

### DIFF
--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -40,7 +40,7 @@ type ProviderConfigStatus struct {
 // A ProviderConfig configures a Template provider.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentialsSecretRef.name",priority=1
+// +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentials.secretRef.name",priority=1
 // +kubebuilder:resource:scope=Cluster
 type ProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/crossplane/provider-template
 go 1.13
 
 require (
-	github.com/crossplane/crossplane-runtime v0.9.1-0.20201001234308-3f1afd106a8c
+	github.com/crossplane/crossplane-runtime v0.10.0
 	github.com/crossplane/crossplane-tools v0.0.0-20201001224552-fb258cc0eb30
 	github.com/google/go-cmp v0.4.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/crossplane/crossplane-runtime v0.9.1-0.20201001234308-3f1afd106a8c h1:jPqFF7MSj5ENEkY6PA2glEJsK5c80Koky5Hz6W04VAY=
 github.com/crossplane/crossplane-runtime v0.9.1-0.20201001234308-3f1afd106a8c/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
+github.com/crossplane/crossplane-runtime v0.10.0 h1:H8YvMcrm1uzZYpwU/BpxjRQfceVulxgYJMx4rmX38Hg=
+github.com/crossplane/crossplane-runtime v0.10.0/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
 github.com/crossplane/crossplane-tools v0.0.0-20201001224552-fb258cc0eb30 h1:NoiOGZCsnrpY4U6sqfiz0RQhi+ohWxFu58rQGoX7MVE=
 github.com/crossplane/crossplane-tools v0.0.0-20201001224552-fb258cc0eb30/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=

--- a/package/crds/template.crossplane.io_providerconfigs.yaml
+++ b/package/crds/template.crossplane.io_providerconfigs.yaml
@@ -12,7 +12,7 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: AGE
     type: date
-  - JSONPath: .spec.credentialsSecretRef.name
+  - JSONPath: .spec.credentials.secretRef.name
     name: SECRET-NAME
     priority: 1
     type: string
@@ -40,23 +40,38 @@ spec:
         spec:
           description: A ProviderConfigSpec defines the desired state of a ProviderConfig.
           properties:
-            credentialsSecretRef:
-              description: CredentialsSecretRef references a specific secret's key that contains the credentials that are used to connect to the provider.
+            credentials:
+              description: Credentials required to authenticate to this provider.
               properties:
-                key:
-                  description: The key to select.
-                  type: string
-                name:
-                  description: Name of the secret.
-                  type: string
-                namespace:
-                  description: Namespace of the secret.
+                secretRef:
+                  description: A CredentialsSecretRef is a reference to a secret key that contains the credentials that must be used to connect to the provider.
+                  properties:
+                    key:
+                      description: The key to select.
+                      type: string
+                    name:
+                      description: Name of the secret.
+                      type: string
+                    namespace:
+                      description: Namespace of the secret.
+                      type: string
+                  required:
+                  - key
+                  - name
+                  - namespace
+                  type: object
+                source:
+                  description: Source of the provider credentials.
+                  enum:
+                  - None
+                  - Secret
+                  - InjectedIdentity
                   type: string
               required:
-              - key
-              - name
-              - namespace
+              - source
               type: object
+          required:
+          - credentials
           type: object
         status:
           description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.

--- a/pkg/controller/mytype/mytype.go
+++ b/pkg/controller/mytype/mytype.go
@@ -102,7 +102,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	// A secret is the most common way to authenticate to a provider, but some
 	// providers additionally support alternative authentication methods such as
 	// IAM, so a reference is not required.
-	ref := pc.Spec.CredentialsSecretRef
+	ref := pc.Spec.Credentials.SecretRef
 	if ref == nil {
 		return nil, errors.New(errNoSecretRef)
 	}


### PR DESCRIPTION
Updates to crossplane-runtime `v0.10.0`, which required some minor changes to `ProviderConfig`.