### PR TITLE
go.mod: bump crossplane-tools to latest

### DIFF
--- a/apis/v1alpha1/zz_generated.pc.go
+++ b/apis/v1alpha1/zz_generated.pc.go
@@ -24,11 +24,6 @@ func (p *ProviderConfig) GetCondition(ct runtimev1alpha1.ConditionType) runtimev
 	return p.Status.GetCondition(ct)
 }
 
-// GetCredentialsSecretReference of this ProviderConfig.
-func (p *ProviderConfig) GetCredentialsSecretReference() *runtimev1alpha1.SecretKeySelector {
-	return p.Spec.CredentialsSecretRef
-}
-
 // GetUsers of this ProviderConfig.
 func (p *ProviderConfig) GetUsers() int64 {
 	return p.Status.Users
@@ -37,11 +32,6 @@ func (p *ProviderConfig) GetUsers() int64 {
 // SetConditions of this ProviderConfig.
 func (p *ProviderConfig) SetConditions(c ...runtimev1alpha1.Condition) {
 	p.Status.SetConditions(c...)
-}
-
-// SetCredentialsSecretReference of this ProviderConfig.
-func (p *ProviderConfig) SetCredentialsSecretReference(r *runtimev1alpha1.SecretKeySelector) {
-	p.Spec.CredentialsSecretRef = r
 }
 
 // SetUsers of this ProviderConfig.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/crossplane/crossplane-runtime v0.10.0
-	github.com/crossplane/crossplane-tools v0.0.0-20201001224552-fb258cc0eb30
+	github.com/crossplane/crossplane-tools v0.0.0-20201007233256-88b291e145bb
 	github.com/google/go-cmp v0.4.0
 	github.com/pkg/errors v0.9.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/crossplane/crossplane-runtime v0.10.0 h1:H8YvMcrm1uzZYpwU/BpxjRQfceVu
 github.com/crossplane/crossplane-runtime v0.10.0/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
 github.com/crossplane/crossplane-tools v0.0.0-20201001224552-fb258cc0eb30 h1:NoiOGZCsnrpY4U6sqfiz0RQhi+ohWxFu58rQGoX7MVE=
 github.com/crossplane/crossplane-tools v0.0.0-20201001224552-fb258cc0eb30/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
+github.com/crossplane/crossplane-tools v0.0.0-20201007233256-88b291e145bb h1:j09j/Gk1qH64HUtf/fcTjMAxLxUdOuQXySWu46WTVTU=
+github.com/crossplane/crossplane-tools v0.0.0-20201007233256-88b291e145bb/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
It doesn't work otherwise.