### PR TITLE
Clean CRDs after generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ all: image image-push install
 
 generate:
 	go generate ./...
+	@find package/crds -name *.yaml -exec sed -i.sed -e '1,2d' {} \;
+	@find package/crds -name *.yaml.sed -delete
 
 lint:
 	$(LINT) run


### PR DESCRIPTION
Leading YAML separators can cause the Crossplane CLI to fail when
building a provider package. This updates generate to clean leading YAML
separators that are added by controller-gen.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>