### PR TITLE
Required import to avoid no auth provider available

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -19,7 +19,7 @@ package main
 import (
 	"os"
 	"path/filepath"
-
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"gopkg.in/alecthomas/kingpin.v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"


### PR DESCRIPTION
When trying to run the template project with make run, you hit this issue
```
ERROR   controller-runtime.manager      Failed to get API Group-Resources       {"error": "no Auth Provider found for name \"gcp\""}
```

Related: https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/46 

This import fixes the problem:
```
_ "k8s.io/client-go/plugin/pkg/client/auth"
```

Which makes kind of sense.. 