### PR TITLE
Add kubebuilder catagories for ProviderConfig and MyType

### DIFF
--- a/apis/sample/v1alpha1/types.go
+++ b/apis/sample/v1alpha1/types.go
@@ -53,7 +53,7 @@ type MyTypeStatus struct {
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // Please replace `PROVIDER-NAME` with your actual provider name, like `aws`, `azure`, `gcp`, `alibaba`
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,PROVIDER-NAME}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,PROVIDER-NAME}
 type MyType struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/sample/v1alpha1/types.go
+++ b/apis/sample/v1alpha1/types.go
@@ -46,13 +46,14 @@ type MyTypeStatus struct {
 
 // +kubebuilder:object:root=true
 
-// A MyType is an example API type
+// A MyType is an example API type.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.atProvider.state"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster
+// Please replace `PROVIDER-NAME` with your actual provider name, like `aws`, `azure`, `gcp`, `alibaba`
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,PROVIDER-NAME}
 type MyType struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -73,7 +73,8 @@ type ProviderConfigList struct {
 // +kubebuilder:printcolumn:name="CONFIG-NAME",type="string",JSONPath=".providerConfigRef.name"
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
-// +kubebuilder:resource:scope=Cluster
+// Please replace `PROVIDER-NAME` with your actual provider name, like `aws`, `azure`, `gcp`, `alibaba`
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,PROVIDER-NAME}
 type ProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/package/crds/sample.template.crossplane.io_mytypes.yaml
+++ b/package/crds/sample.template.crossplane.io_mytypes.yaml
@@ -10,7 +10,7 @@ spec:
   names:
     categories:
     - crossplane
-    - provider
+    - managed
     - PROVIDER-NAME
     kind: MyType
     listKind: MyTypeList
@@ -34,7 +34,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A MyType is an example API type Please replace `PROVIDER-NAME` with your actual provider name, like `aws`, `azure`, `gcp`, `alibaba`
+        description: A MyType is an example API type. Please replace `PROVIDER-NAME` with your actual provider name, like `aws`, `azure`, `gcp`, `alibaba`
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/package/crds/sample.template.crossplane.io_mytypes.yaml
+++ b/package/crds/sample.template.crossplane.io_mytypes.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: sample.template.crossplane.io
   names:
+    categories:
+    - crossplane
+    - provider
+    - PROVIDER-NAME
     kind: MyType
     listKind: MyTypeList
     plural: mytypes
@@ -30,7 +34,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A MyType is an example API type
+        description: A MyType is an example API type Please replace `PROVIDER-NAME` with your actual provider name, like `aws`, `azure`, `gcp`, `alibaba`
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/package/crds/template.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/template.crossplane.io_providerconfigusages.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: template.crossplane.io
   names:
+    categories:
+    - crossplane
+    - provider
+    - PROVIDER-NAME
     kind: ProviderConfigUsage
     listKind: ProviderConfigUsageList
     plural: providerconfigusages
@@ -30,7 +34,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A ProviderConfigUsage indicates that a resource is using a ProviderConfig.
+        description: A ProviderConfigUsage indicates that a resource is using a ProviderConfig. Please replace `PROVIDER-NAME` with your actual provider name, like `aws`, `azure`, `gcp`, `alibaba`
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'


### PR DESCRIPTION
Added kubebuilder catagories {crossplane,provider,PROVIDER-NAME}
in the template.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>

Refer to https://github.com/crossplane/provider-alibaba/pull/64#discussion_r599354919