### PR TITLE
remove .spec.classRef.name print column

### DIFF
--- a/apis/sample/v1alpha1/types.go
+++ b/apis/sample/v1alpha1/types.go
@@ -50,7 +50,6 @@ type MyTypeStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.atProvider.state"
-// +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster
 type MyType struct {


### PR DESCRIPTION
The following line was not pointing to an existing property of the spec type
```
// +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"
```