### PR TITLE
Dockerfile to copy internal instead of pkg

### DIFF
--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 # Copy the go source
 COPY cmd/ cmd/
 COPY apis/ apis/
-COPY pkg/ pkg/
+COPY internal/ internal/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o provider cmd/provider/main.go


### PR DESCRIPTION
I think that `pkg` was used before, but now it is called `internal`, 
But please check.. I might be missing something. 