### PR TITLE
updating go mod to 1.16

### DIFF
--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/provider-template
 
-go 1.13
+go 1.16
 
 require (
 	github.com/crossplane/crossplane-runtime v0.13.0


### PR DESCRIPTION
closes #30 and fixes the problem mentioned in the issue. 
Upgrade the mod and the Dockerfile which defines which go builder version is going to be used to build the image. 