### PR TITLE
adding a crossplane.yaml to the template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ build: generate test
 	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o ./bin/$(PROVIDER_NAME)-controller cmd/provider/main.go
 
 image: generate test
-	docker build . -t $(ORG_NAME)/$(PROVIDER_NAME):latest -f cluster/Dockerfile
+	docker build . -t $(ORG_NAME)/$(PROVIDER_NAME)-controller:latest -f cluster/Dockerfile
 
 image-push:
-	docker push $(ORG_NAME)/$(PROVIDER_NAME):latest
+	docker push $(ORG_NAME)/$(PROVIDER_NAME)-controller:latest
 
 run: generate
 	kubectl apply -f package/crds/ -R

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -10,4 +10,4 @@ metadata:
 
 spec:
   controller:
-    image: crossplane/provider-template-controller:v0.0.1
+    image: crossplane/provider-template-controller:latest

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -10,4 +10,4 @@ metadata:
 
 spec:
   controller:
-    image: salaboy/provider-template-controller:v0.0.1
+    image: crossplane/provider-template-controller:v0.0.1

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -1,0 +1,13 @@
+apiVersion: meta.pkg.crossplane.io/v1alpha1
+kind: Provider
+metadata:
+  name: provider-template
+  annotations:
+    company: Template
+    maintainer: template <template@mail.com>
+    source: github.com/crossplane/provider-template
+    license: Apache-2.0
+
+spec:
+  controller:
+    image: salaboy/provider-template-controller:v0.0.1


### PR DESCRIPTION
This PR adds a crossplane.yaml example file to be able to package and distribute the provider. 
This PR also includes a change in the name of the docker image generated by the make file adding `-controller` because I've seen in other providers and also in online tutorials that this pattern is being used.. For me, it was more clear to be able to differentiate the -controller image and the provider image.