### PR TITLE
Update import linting prefix

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters-settings:
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
-    local-prefixes: github.com/crossplane/provider-gcp
+    local-prefixes: github.com/crossplane/provider-template
 
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)


### PR DESCRIPTION
The `local-prefixes` setting for linting with `goimports` was not replaced to match the template module path, so is easily missed with a search and replace on a new provider.

Signed-off-by: Ben Agricola <bagricola@squiz.co.uk>