### PR TITLE
Update find parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ all: image image-push
 
 generate:
 	go generate ./...
-	@find package/crds -name *.yaml -exec sed -i.sed -e '1,2d' {} \;
-	@find package/crds -name *.yaml.sed -delete
+	@find package/crds -name \*.yaml -exec sed -i.sed -e '1,2d' {} \;
+	@find package/crds -name \*.yaml.sed -delete
 
 lint:
 	$(LINT) run


### PR DESCRIPTION
Use single quote  (or backslash ) to protect * (in *.yaml) from interpretation as shell script punctuation. 

I'm using Ubuntu as my dev node , but find some weird things , that when using `kubectl crossplane build provider` , it will prompt error 

```
# kubectl crossplane build provider
kubectl crossplane: error: failed to build package: failed to parse package: {path:/root/go/src/github.ibm.com/jbjhuang/cloudpak-provider/package/crds/cloudpak.crossplane.io_dependencies.yaml position:4096}: Object 'Kind' is missing in '
                           '
```

After several round check and test , finally found it's due to first two lines in crd

```
# cat crds/cloudpak.crossplane.io_dependencies.yaml

---
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
```

It supposes to be remoted by `Makefile` scripts below , but failed , at least in ubuntu env

```
generate:
	go generate ./...
	@find package/crds -name *.yaml -exec sed -i.sed -e '1,2d' {} \;
	@find package/crds -name *.yaml.sed -delete
```

