### PR TITLE
Add muvaf as provider-template maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -12,3 +12,4 @@ guidelines and responsibilities for the steering committee and maintainers.
 
 * Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
 * Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))
+* Muvaffak Onuş <monus@upbound.io> ([muvaf](https://github.com/muvaf))


### PR DESCRIPTION
Adds muvaf as a provider-template maintainer in accordance with
crossplane/crossplane GOVERNANCE.md.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>