### PR TITLE
go.generate: delete all generated Go files before running code generators

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ run:
   deadline: 2m
 
   skip-files:
-  - "zz_generated\\..+\\.go$"
+  - "zz_\\..+\\.go$"
 
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"

--- a/apis/generate.go
+++ b/apis/generate.go
@@ -22,6 +22,12 @@ limitations under the License.
 // Remove existing CRDs
 //go:generate rm -rf ../package/crds
 
+// Remove generated Go files
+//go:generate bash -c "find . -iname 'zz_*' -delete"
+//go:generate bash -c "find . -type d -empty -delete"
+//go:generate bash -c "find ../internal/controller -iname 'zz_*' -delete"
+//go:generate bash -c "find ../internal/controller -type d -empty -delete"
+
 // Generate deepcopy methodsets and CRD manifests
 //go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile=../hack/boilerplate.go.txt paths=./... crd:trivialVersions=true,crdVersions=v1 output:artifacts:config=../package/crds
 


### PR DESCRIPTION
angryjet does not generate new files if the methods already exist so we have to delete generated files manually. This change makes that part of `go generate ./...` call.