### PR TITLE
Build update for up binary and integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ GO_SUBDIRS += cmd internal apis
 GO111MODULE = on
 -include build/makelib/golang.mk
 
+# kind-related versions
+KIND_VERSION ?= v0.12.0
+KIND_NODE_IMAGE_TAG ?= v1.23.4
+
 # Setup Kubernetes tools
 -include build/makelib/k8s_tools.mk
 
@@ -42,9 +46,9 @@ generate: crds.clean
 e2e.run: test-integration
 
 # Run integration tests.
-test-integration: $(KIND) $(KUBECTL) $(HELM3)
+test-integration: $(KIND) $(KUBECTL) $(UP) $(HELM3)
 	@$(INFO) running integration tests using kind $(KIND_VERSION)
-	@$(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
+	@KIND_NODE_IMAGE_TAG=${KIND_NODE_IMAGE_TAG} $(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
 	@$(OK) integration tests passed
 
 # Update the submodules, such as the common build scripts.

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -51,7 +51,7 @@ PACKAGE_CONTROLLER_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}-controller:${VERSIO
 K8S_CLUSTER="${K8S_CLUSTER:-${BUILD_REGISTRY}-inttests}"
 
 CROSSPLANE_NAMESPACE="crossplane-system"
-PACKAGE_NAME="provider-aws"
+PACKAGE_NAME="provider-kafka"
 
 # cleanup on exit
 if [ "$skipcleanup" != true ]; then

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -e
+
+# setting up colors
+BLU='\033[0;34m'
+YLW='\033[0;33m'
+GRN='\033[0;32m'
+RED='\033[0;31m'
+NOC='\033[0m' # No Color
+echo_info(){
+    printf "\n${BLU}%s${NOC}" "$1"
+}
+echo_step(){
+    printf "\n${BLU}>>>>>>> %s${NOC}\n" "$1"
+}
+echo_sub_step(){
+    printf "\n${BLU}>>> %s${NOC}\n" "$1"
+}
+
+echo_step_completed(){
+    printf "${GRN} [✔]${NOC}"
+}
+
+echo_success(){
+    printf "\n${GRN}%s${NOC}\n" "$1"
+}
+echo_warn(){
+    printf "\n${YLW}%s${NOC}" "$1"
+}
+echo_error(){
+    printf "\n${RED}%s${NOC}" "$1"
+    exit 1
+}
+
+# ------------------------------
+projectdir="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../.. && pwd )"
+
+# get the build environment variables from the special build.vars target in the main makefile
+eval $(make --no-print-directory -C ${projectdir} build.vars)
+
+# ------------------------------
+
+SAFEHOSTARCH="${SAFEHOSTARCH:-amd64}"
+BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${SAFEHOSTARCH}"
+PACKAGE_IMAGE="crossplane.io/inttests/${PROJECT_NAME}:${VERSION}"
+CONTROLLER_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-controller-${SAFEHOSTARCH}"
+
+version_tag="$(cat ${projectdir}/_output/version)"
+# tag as latest version to load into kind cluster
+PACKAGE_CONTROLLER_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}-controller:${VERSION}"
+K8S_CLUSTER="${K8S_CLUSTER:-${BUILD_REGISTRY}-inttests}"
+
+CROSSPLANE_NAMESPACE="crossplane-system"
+PACKAGE_NAME="provider-aws"
+
+# cleanup on exit
+if [ "$skipcleanup" != true ]; then
+  function cleanup {
+    echo_step "Cleaning up..."
+    export KUBECONFIG=
+    "${KIND}" delete cluster --name="${K8S_CLUSTER}"
+  }
+
+  trap cleanup EXIT
+fi
+
+# setup package cache
+echo_step "setting up local package cache"
+CACHE_PATH="${projectdir}/.work/inttest-package-cache"
+mkdir -p "${CACHE_PATH}"
+echo "created cache dir at ${CACHE_PATH}"
+docker tag "${BUILD_IMAGE}" "${PACKAGE_IMAGE}"
+"${UP}" xpkg xp-extract --from-daemon "${PACKAGE_IMAGE}" -o "${CACHE_PATH}/${PACKAGE_NAME}.gz" && chmod 644 "${CACHE_PATH}/${PACKAGE_NAME}.gz"
+
+# create kind cluster with extra mounts
+KIND_NODE_IMAGE="kindest/node:${KIND_NODE_IMAGE_TAG}"
+echo_step "creating k8s cluster using kind ${KIND_VERSION} and node image ${KIND_NODE_IMAGE}"
+KIND_CONFIG="$( cat <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: "${CACHE_PATH}/"
+    containerPath: /cache
+EOF
+)"
+echo "${KIND_CONFIG}" | "${KIND}" create cluster --name="${K8S_CLUSTER}" --wait=5m --image="${KIND_NODE_IMAGE}" --config=-
+
+# tag controller image and load it into kind cluster
+docker tag "${CONTROLLER_IMAGE}" "${PACKAGE_CONTROLLER_IMAGE}"
+"${KIND}" load docker-image "${PACKAGE_CONTROLLER_IMAGE}" --name="${K8S_CLUSTER}"
+
+echo_step "create crossplane-system namespace"
+"${KUBECTL}" create ns crossplane-system
+
+echo_step "create persistent volume and claim for mounting package-cache"
+PV_YAML="$( cat <<EOF
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: package-cache
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 5Mi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/cache"
+EOF
+)"
+echo "${PV_YAML}" | "${KUBECTL}" create -f -
+
+PVC_YAML="$( cat <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: package-cache
+  namespace: crossplane-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeName: package-cache
+  storageClassName: manual
+  resources:
+    requests:
+      storage: 1Mi
+EOF
+)"
+echo "${PVC_YAML}" | "${KUBECTL}" create -f -
+
+# install crossplane from stable channel
+echo_step "installing crossplane from stable channel"
+"${HELM3}" repo add crossplane-stable https://charts.crossplane.io/stable/
+chart_version="$("${HELM3}" search repo crossplane-stable/crossplane | awk 'FNR == 2 {print $2}')"
+echo_info "using crossplane version ${chart_version}"
+echo
+# we replace empty dir with our PVC so that the /cache dir in the kind node
+# container is exposed to the crossplane pod
+"${HELM3}" install crossplane --namespace crossplane-system crossplane-stable/crossplane --version ${chart_version} --wait --set packageCache.pvc=package-cache
+
+# ----------- integration tests
+echo_step "--- INTEGRATION TESTS ---"
+
+# install package
+echo_step "installing ${PROJECT_NAME} into \"${CROSSPLANE_NAMESPACE}\" namespace"
+
+INSTALL_YAML="$( cat <<EOF
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: "${PACKAGE_NAME}"
+spec:
+  package: "${PACKAGE_NAME}"
+  packagePullPolicy: Never
+EOF
+)"
+
+echo "${INSTALL_YAML}" | "${KUBECTL}" apply -f -
+
+# printing the cache dir contents can be useful for troubleshooting failures
+echo_step "check kind node cache dir contents"
+docker exec "${K8S_CLUSTER}-control-plane" ls -la /cache
+
+echo_step "waiting for provider to be installed"
+
+kubectl wait "provider.pkg.crossplane.io/${PACKAGE_NAME}" --for=condition=healthy --timeout=180s
+
+echo_step "uninstalling ${PROJECT_NAME}"
+
+echo "${INSTALL_YAML}" | "${KUBECTL}" delete -f -
+
+# check pods deleted
+timeout=60
+current=0
+step=3
+while [[ $(kubectl get providerrevision.pkg.crossplane.io -o name | wc -l) != "0" ]]; do
+  echo "waiting for provider to be deleted for another $step seconds"
+  current=$current+$step
+  if ! [[ $timeout > $current ]]; then
+    echo_error "timeout of ${timeout}s has been reached"
+  fi
+  sleep $step;
+done
+
+echo_success "Integration tests succeeded!"

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -32,6 +32,11 @@ echo_error(){
     exit 1
 }
 
+
+# The name of your provider. Many provider Makefiles override this value.
+PACKAGE_NAME="provider-template"
+
+
 # ------------------------------
 projectdir="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../.. && pwd )"
 
@@ -51,7 +56,6 @@ PACKAGE_CONTROLLER_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}-controller:${VERSIO
 K8S_CLUSTER="${K8S_CLUSTER:-${BUILD_REGISTRY}-inttests}"
 
 CROSSPLANE_NAMESPACE="crossplane-system"
-PACKAGE_NAME="provider-kafka"
 
 # cleanup on exit
 if [ "$skipcleanup" != true ]; then


### PR DESCRIPTION

### Description of your changes

Updates the `Makefile` and adds integration test script for the `e2e` target. The `cluster/local/integration_tests.sh` script is used by several other providers. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Ran `make e2e`

[contribution process]: https://git.io/fj2m9
