### PR TITLE
Add helper make targets to prepare repo and add new types

### DIFF
--- a/hack/helpers/addtype.sh
+++ b/hack/helpers/addtype.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Crossplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Please set ProviderNameLower & ProviderNameUpper environment variables before running this script.
+# See: https://github.com/crossplane/terrajet/blob/main/docs/generating-a-provider.md
+set -euo pipefail
+
+APIVERSION="${APIVERSION:-v1alpha1}"
+echo "Adding type ${KIND} to group ${GROUP} with version ${APIVERSION}"
+
+export GROUP
+export KIND
+export APIVERSION
+export PROVIDER
+
+kind_lower=$(echo "${KIND}" | tr "[:upper:]" "[:lower:]")
+group_lower=$(echo "${GROUP}" | tr "[:upper:]" "[:lower:]")
+
+mkdir -p "apis/${group_lower}/${APIVERSION}"
+${GOMPLATE} < "hack/helpers/apis/GROUP_LOWER/GROUP_LOWER.go.tmpl" > "apis/${group_lower}/${group_lower}.go"
+${GOMPLATE} < "hack/helpers/apis/GROUP_LOWER/APIVERSION/KIND_LOWER_types.go.tmpl" > "apis/${group_lower}/${APIVERSION}/${kind_lower}_types.go"
+${GOMPLATE} < "hack/helpers/apis/GROUP_LOWER/APIVERSION/doc.go.tmpl" > "apis/${group_lower}/${APIVERSION}/doc.go"
+${GOMPLATE} < "hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl" > "apis/${group_lower}/${APIVERSION}/groupversion_info.go"
+
+mkdir -p "internal/controller/${kind_lower}"
+${GOMPLATE} < "hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl" > "internal/controller/${kind_lower}/${kind_lower}.go"
+${GOMPLATE} < "hack/helpers/controller/KIND_LOWER/KIND_LOWER_test.go.tmpl" > "internal/controller/${kind_lower}/${kind_lower}_test.go"
+
+
+

--- a/hack/helpers/apis/GROUP_LOWER/APIVERSION/KIND_LOWER_types.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/APIVERSION/KIND_LOWER_types.go.tmpl
@@ -1,0 +1,86 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package {{ .Env.APIVERSION }}
+
+import (
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+)
+
+// {{ .Env.KIND }}Parameters are the configurable fields of a {{ .Env.KIND }}.
+type {{ .Env.KIND }}Parameters struct {
+	ConfigurableField string `json:"configurableField"`
+}
+
+// {{ .Env.KIND }}Observation are the observable fields of a {{ .Env.KIND }}.
+type {{ .Env.KIND }}Observation struct {
+	ObservableField string `json:"observableField,omitempty"`
+}
+
+// A {{ .Env.KIND }}Spec defines the desired state of a {{ .Env.KIND }}.
+type {{ .Env.KIND }}Spec struct {
+	xpv1.ResourceSpec `json:",inline"`
+	ForProvider       {{ .Env.KIND }}Parameters `json:"forProvider"`
+}
+
+// A {{ .Env.KIND }}Status represents the observed state of a {{ .Env.KIND }}.
+type {{ .Env.KIND }}Status struct {
+	xpv1.ResourceStatus `json:",inline"`
+	AtProvider          {{ .Env.KIND }}Observation `json:"atProvider,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// A {{ .Env.KIND }} is an example API type.
+// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
+// +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,{{ .Env.PROVIDER | strings.ToLower }}}
+type {{ .Env.KIND }} struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   {{ .Env.KIND }}Spec   `json:"spec"`
+	Status {{ .Env.KIND }}Status `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// {{ .Env.KIND }}List contains a list of {{ .Env.KIND }}
+type {{ .Env.KIND }}List struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []{{ .Env.KIND }} `json:"items"`
+}
+
+// {{ .Env.KIND }} type metadata.
+var (
+	{{ .Env.KIND }}Kind             = reflect.TypeOf({{ .Env.KIND }}{}).Name()
+	{{ .Env.KIND }}GroupKind        = schema.GroupKind{Group: Group, Kind: {{ .Env.KIND }}Kind}.String()
+	{{ .Env.KIND }}KindAPIVersion   = {{ .Env.KIND }}Kind + "." + SchemeGroupVersion.String()
+	{{ .Env.KIND }}GroupVersionKind = SchemeGroupVersion.WithKind({{ .Env.KIND }}Kind)
+)
+
+func init() {
+	SchemeBuilder.Register(&{{ .Env.KIND }}{}, &{{ .Env.KIND }}List{})
+}

--- a/hack/helpers/apis/GROUP_LOWER/APIVERSION/doc.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/APIVERSION/doc.go.tmpl
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package {{ .Env.APIVERSION | strings.ToLower }}

--- a/hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1alpha1 contains the v1alpha1 group Sample resources of the {{ .Env.PROVIDER }} provider.
+// +kubebuilder:object:generate=true
+// +groupName={{ .Env.GROUP | strings.ToLower }}.{{ .Env.PROVIDER | strings.ToLower }}.crossplane.io
+// +versionName={{ .Env.APIVERSION | strings.ToLower }}
+package {{ .Env.APIVERSION | strings.ToLower }}
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+// Package type metadata.
+const (
+	Group   = "{{ .Env.GROUP | strings.ToLower }}.{{ .Env.PROVIDER | strings.ToLower }}.crossplane.io"
+	Version = "{{ .Env.APIVERSION | strings.ToLower }}"
+)
+
+var (
+	// SchemeGroupVersion is group version used to register these objects
+	SchemeGroupVersion = schema.GroupVersion{Group: Group, Version: Version}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+)

--- a/hack/helpers/apis/GROUP_LOWER/GROUP_LOWER.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/GROUP_LOWER.go.tmpl
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package {{ .Env.GROUP | strings.ToLower }} contains group {{ .Env.GROUP }} API versions
+package {{ .Env.GROUP | strings.ToLower }}

--- a/hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl
+++ b/hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl
@@ -1,0 +1,197 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package {{ .Env.KIND | strings.ToLower }}
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/connection"
+	"github.com/crossplane/crossplane-runtime/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+
+	"github.com/crossplane/provider-{{ .Env.PROVIDER | strings.ToLower }}/apis/{{ .Env.GROUP | strings.ToLower }}/{{ .Env.APIVERSION | strings.ToLower }}"
+	apisv1alpha1 "github.com/crossplane/provider-{{ .Env.PROVIDER | strings.ToLower }}/apis/v1alpha1"
+	"github.com/crossplane/provider-{{ .Env.PROVIDER | strings.ToLower }}/internal/controller/features"
+)
+
+const (
+	errNot{{ .Env.KIND }}    = "managed resource is not a {{ .Env.KIND }} custom resource"
+	errTrackPCUsage = "cannot track ProviderConfig usage"
+	errGetPC        = "cannot get ProviderConfig"
+	errGetCreds     = "cannot get credentials"
+
+	errNewClient = "cannot create new Service"
+)
+
+// A NoOpService does nothing.
+type NoOpService struct{}
+
+var (
+	newNoOpService = func(_ []byte) (interface{}, error) { return &NoOpService{}, nil }
+)
+
+// Setup adds a controller that reconciles {{ .Env.KIND }} managed resources.
+func Setup(mgr ctrl.Manager, o controller.Options) error {
+	name := managed.ControllerName(v1alpha1.{{ .Env.KIND }}GroupKind)
+
+	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
+	if o.Features.Enabled(features.EnableAlphaExternalSecretStores) {
+		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), apisv1alpha1.StoreConfigGroupVersionKind))
+	}
+
+	r := managed.NewReconciler(mgr,
+		resource.ManagedKind(v1alpha1.{{ .Env.KIND }}GroupVersionKind),
+		managed.WithExternalConnecter(&connector{
+			kube:         mgr.GetClient(),
+			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
+			newServiceFn: newNoOpService}),
+		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
+		managed.WithConnectionPublishers(cps...))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		WithOptions(o.ForControllerRuntime()).
+		For(&v1alpha1.{{ .Env.KIND }}{}).
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
+}
+
+// A connector is expected to produce an ExternalClient when its Connect method
+// is called.
+type connector struct {
+	kube         client.Client
+	usage        resource.Tracker
+	newServiceFn func(creds []byte) (interface{}, error)
+}
+
+// Connect typically produces an ExternalClient by:
+// 1. Tracking that the managed resource is using a ProviderConfig.
+// 2. Getting the managed resource's ProviderConfig.
+// 3. Getting the credentials specified by the ProviderConfig.
+// 4. Using the credentials to form a client.
+func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
+	cr, ok := mg.(*v1alpha1.{{ .Env.KIND }})
+	if !ok {
+		return nil, errors.New(errNot{{ .Env.KIND }})
+	}
+
+	if err := c.usage.Track(ctx, mg); err != nil {
+		return nil, errors.Wrap(err, errTrackPCUsage)
+	}
+
+	pc := &apisv1alpha1.ProviderConfig{}
+	if err := c.kube.Get(ctx, types.NamespacedName{Name: cr.GetProviderConfigReference().Name}, pc); err != nil {
+		return nil, errors.Wrap(err, errGetPC)
+	}
+
+	cd := pc.Spec.Credentials
+	data, err := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
+	if err != nil {
+		return nil, errors.Wrap(err, errGetCreds)
+	}
+
+	svc, err := c.newServiceFn(data)
+	if err != nil {
+		return nil, errors.Wrap(err, errNewClient)
+	}
+
+	return &external{service: svc}, nil
+}
+
+// An ExternalClient observes, then either creates, updates, or deletes an
+// external resource to ensure it reflects the managed resource's desired state.
+type external struct {
+	// A 'client' used to connect to the external resource API. In practice this
+	// would be something like an AWS SDK client.
+	service interface{}
+}
+
+func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
+	cr, ok := mg.(*v1alpha1.{{ .Env.KIND }})
+	if !ok {
+		return managed.ExternalObservation{}, errors.New(errNot{{ .Env.KIND }})
+	}
+
+	// These fmt statements should be removed in the real implementation.
+	fmt.Printf("Observing: %+v", cr)
+
+	return managed.ExternalObservation{
+		// Return false when the external resource does not exist. This lets
+		// the managed resource reconciler know that it needs to call Create to
+		// (re)create the resource, or that it has successfully been deleted.
+		ResourceExists: true,
+
+		// Return false when the external resource exists, but it not up to date
+		// with the desired managed resource state. This lets the managed
+		// resource reconciler know that it needs to call Update.
+		ResourceUpToDate: true,
+
+		// Return any details that may be required to connect to the external
+		// resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
+	cr, ok := mg.(*v1alpha1.{{ .Env.KIND }})
+	if !ok {
+		return managed.ExternalCreation{}, errors.New(errNot{{ .Env.KIND }})
+	}
+
+	fmt.Printf("Creating: %+v", cr)
+
+	return managed.ExternalCreation{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
+	cr, ok := mg.(*v1alpha1.{{ .Env.KIND }})
+	if !ok {
+		return managed.ExternalUpdate{}, errors.New(errNot{{ .Env.KIND }})
+	}
+
+	fmt.Printf("Updating: %+v", cr)
+
+	return managed.ExternalUpdate{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
+	cr, ok := mg.(*v1alpha1.{{ .Env.KIND }})
+	if !ok {
+		return errors.New(errNot{{ .Env.KIND }})
+	}
+
+	fmt.Printf("Deleting: %+v", cr)
+
+	return nil
+}

--- a/hack/helpers/controller/KIND_LOWER/KIND_LOWER_test.go.tmpl
+++ b/hack/helpers/controller/KIND_LOWER/KIND_LOWER_test.go.tmpl
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package {{ .Env.KIND | strings.ToLower }}
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+// Unlike many Kubernetes projects Crossplane does not use third party testing
+// libraries, per the common Go test review comments. Crossplane encourages the
+// use of table driven unit tests. The tests of the crossplane-runtime project
+// are representative of the testing style Crossplane encourages.
+//
+// https://github.com/golang/go/wiki/TestComments
+// https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#contributing-code
+
+func TestObserve(t *testing.T) {
+	type fields struct {
+		service interface{}
+	}
+
+	type args struct {
+		ctx context.Context
+		mg  resource.Managed
+	}
+
+	type want struct {
+		o   managed.ExternalObservation
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		fields fields
+		args   args
+		want   want
+	}{
+		// TODO: Add test cases.
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := external{service: tc.fields.service}
+			got, err := e.Observe(tc.args.ctx, tc.args.mg)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.o, got); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/hack/helpers/prepare.sh
+++ b/hack/helpers/prepare.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Crossplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Please set ProviderNameLower & ProviderNameUpper environment variables before running this script.
+# See: https://github.com/crossplane/terrajet/blob/main/docs/generating-a-provider.md
+set -euo pipefail
+
+ProviderNameUpper=${PROVIDER}
+ProviderNameLower=$(echo "${PROVIDER}" | tr "[:upper:]" "[:lower:]")
+
+git rm -r apis/sample
+git rm -r internal/controller/mytype
+
+REPLACE_FILES='./* ./.github :!build/** :!go.* :!hack/**'
+# shellcheck disable=SC2086
+git grep -l 'template' -- ${REPLACE_FILES} | xargs sed -i.bak "s/template/${ProviderNameLower}/g"
+# shellcheck disable=SC2086
+git grep -l 'Template' -- ${REPLACE_FILES} | xargs sed -i.bak "s/Template/${ProviderNameUpper}/g"
+# We need to be careful while replacing "template" keyword in go.mod as it could tamper
+# some imported packages under require section.
+sed -i.bak "s/provider-template/provider-${ProviderNameLower}/g" go.mod
+
+# Clean up the .bak files created by sed
+git clean -fd
+
+git mv "apis/template.go" "apis/${ProviderNameLower}.go"
+git mv "internal/controller/template.go" "internal/controller/${ProviderNameLower}.go"
+git mv "cluster/images/provider-template" "cluster/images/provider-${ProviderNameLower}"
+git mv "cluster/images/provider-template-controller" "cluster/images/provider-${ProviderNameLower}-controller"


### PR DESCRIPTION
### Description of your changes

This PR adds the following two make targets:

```makefile
# This target prepares repo for your provider by replacing all "template"
# occurrences with your provider name.
# This target can only be run once, if you want to rerun for some reason,
# consider stashing/resetting your git state.
# Arguments:
#   provider: Camel case name of your provider, e.g. GitHub, PlanetScale
provider.prepare:
```

```makefile
# This target adds a new api type and its controller.
# You would still need to register new api in "apis/<provider>.go" and
# controller in "internal/controller/<provider>.go".
# Arguments:
#   provider: Camel case name of your provider, e.g. GitHub, PlanetScale
#   group: API group for the type you want to add.
#   kind: Kind of the type you want to add
#	apiversion: API version of the type you want to add. Optional and defaults to "v1alpha1"
provider.addtype:
```


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

```console
make provider.prepare provider=GitHub

make provider.addtype provider=GitHub group=Organization kind=Project

# Register the new API in "apis/github.go"
# Register the new Controller in "internal/controller/github.go"

make generate
```

[contribution process]: https://git.io/fj2m9
