### PR TITLE
Fix gomplate installation if cache not set up before

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ GOMPLATE := $(TOOLS_HOST_DIR)/gomplate-$(GOMPLATE_VERSION)
 
 $(GOMPLATE):
 	@$(INFO) installing gomplate $(SAFEHOSTPLATFORM)
+	@mkdir -p $(TOOLS_HOST_DIR)
 	@curl -fsSLo $(GOMPLATE) https://github.com/hairyhenderson/gomplate/releases/download/v$(GOMPLATE_VERSION)/gomplate_$(SAFEHOSTPLATFORM) || $(FAIL)
 	@chmod +x $(GOMPLATE)
 	@$(OK) installing gomplate $(SAFEHOSTPLATFORM)


### PR DESCRIPTION
### Description of your changes

A follow up fix after PR #50 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

On a clean fork:

```
make provider.addtype provider=GitHub group=Organization kind=Projecrt
```

[contribution process]: https://git.io/fj2m9
