### PR TITLE
Remove clean.crds from Makefile.  Fixes #56

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,6 @@ fallthrough: submodules
 	@echo Initial setup complete. Running make again . . .
 	@make
 
-crds.clean:
-	@$(INFO) cleaning generated CRDs
-	@find package/crds -name *.yaml -exec sed -i.sed -e '1,2d' {} \; || $(FAIL)
-	@find package/crds -name *.yaml.sed -delete || $(FAIL)
-	@$(OK) cleaned generated CRDs
-
-generate: crds.clean
-
 # integration tests
 e2e.run: test-integration
 
@@ -88,7 +80,7 @@ dev-clean: $(KIND) $(KUBECTL)
 	@$(INFO) Deleting kind cluster
 	@$(KIND) delete cluster --name=$(PROJECT_NAME)-dev
 
-.PHONY: submodules fallthrough test-integration run crds.clean dev dev-clean
+.PHONY: submodules fallthrough test-integration run dev dev-clean
 
 # ====================================================================================
 # Special Targets


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes
Removed clean.crds target from Makefile as it appears to be a noop.

Fixes #56 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Verified that make command produces no deltas with this change
[contribution process]: https://git.io/fj2m9
