### PR TITLE
Bump backport-action to v1 major release

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,13 +22,7 @@ jobs:
     if: github.event.pull_request.merged
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v3
 
       - name: Open Backport PR
-        uses: zeebe-io/backport-action@v0.0.4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          github_workspace: ${{ github.workspace }}
-          version: v0.0.4
+        uses: korthout/backport-action@v1

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,8 +15,8 @@ jobs:
   # one. Many do not support merge commits, or do not support pull requests with
   # more than one commit. This one does. It also handily links backport PRs with
   # new PRs, and provides commentary and instructions when it can't backport.
-  # The main gotchas with this action are that it _only_ supports merge commits,
-  # and that PRs _must_ be labelled before they're merged to trigger a backport.
+  # The main gotcha with this action is that PRs _must_ be labelled before they're
+  # merged to trigger a backport.
   open-pr:
     runs-on: ubuntu-22.04
     if: github.event.pull_request.merged

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -83,4 +83,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Open Backport PR
-      uses: zeebe-io/backport-action@v1
+      uses: korthout/backport-action@v1

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -80,13 +80,7 @@ jobs:
         permission-level: write
 
     - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      uses: actions/checkout@v3
 
     - name: Open Backport PR
-      uses: zeebe-io/backport-action@v0.0.4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        github_workspace: ${{ github.workspace }}
-        version: v0.0.4
+      uses: zeebe-io/backport-action@v1


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This pull requests bumps the backport-action to its latest version, and adjusts the workflow accordingly.

The `v1` release of this backport-action has a few improvements:
- faster, it no longer requires fetch-depth 0 checkouts and it fetches only the necessary commits
- major release tag moves along with patches (SemVer)
- it no longer requires any inputs by default

Note that the repo moved from zeebe-io to korthout. See [releases notes v1.0.0](https://github.com/korthout/backport-action/releases/tag/v1.0.0).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- Zeebe itself has switched to this version https://github.com/camunda/zeebe/blob/main/.github/workflows/backport.yml#L30
- The action is tested using https://github.com/korthout/backport-action-test

[contribution process]: https://git.io/fj2m9
