### PR TITLE
Fix Makefile dev: Apply server-side to prevent CRD being too large

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ dev: $(KIND) $(KUBECTL)
 	@$(KIND) create cluster --name=$(PROJECT_NAME)-dev
 	@$(KUBECTL) cluster-info --context kind-$(PROJECT_NAME)-dev
 	@$(INFO) Installing Crossplane CRDs
-	@$(KUBECTL) apply -k https://github.com/crossplane/crossplane//cluster?ref=master
+	@$(KUBECTL) apply --server-side -k https://github.com/crossplane/crossplane//cluster?ref=master
 	@$(INFO) Installing Provider Template CRDs
 	@$(KUBECTL) apply -R -f package/crds
 	@$(INFO) Starting Provider Template controllers


### PR DESCRIPTION
### Description of your changes

Details in https://github.com/crossplane/crossplane/issues/5336

I assume the PR checklists are not relevant as this PR is not for the functionality of crossplane/provider, just a fix for the dev script.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

