### PR TITLE
ci: apply correct permissions to codeql job

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,10 @@ on:
       - release-*
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   detect-noop:
     runs-on: ubuntu-22.04
@@ -34,9 +38,9 @@ jobs:
           submodules: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: go
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->



Applies the `contents:read` and `security-events:write` permissions to the CodeQL job. Also bumps the Action to v3 as [deprecated](https://github.com/github/codeql-action/?tab=readme-ov-file#supported-versions-of-the-codeql-action).

The reason for the change is because the template's Actions don't work out of the box. This addresses that.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- [Original broken Action](https://github.com/mrsimonemms/crossplane-provider-hetzner/actions/runs/11071217110)
- [Fixed Action with this change in](https://github.com/mrsimonemms/crossplane-provider-hetzner/actions/runs/11071293997)

[contribution process]: https://git.io/fj2m9
