### PR TITLE
Removes unnecessary apply of Crossplane CRDs #104

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,6 @@ dev: $(KIND) $(KUBECTL)
 	@$(INFO) Creating kind cluster
 	@$(KIND) create cluster --name=$(PROJECT_NAME)-dev
 	@$(KUBECTL) cluster-info --context kind-$(PROJECT_NAME)-dev
-	@$(INFO) Installing Crossplane CRDs
-	@$(KUBECTL) apply --server-side -k https://github.com/crossplane/crossplane//cluster?ref=master
 	@$(INFO) Installing Provider Template CRDs
 	@$(KUBECTL) apply -R -f package/crds
 	@$(INFO) Starting Provider Template controllers


### PR DESCRIPTION
### Description of your changes

Removed broken and unnecessary installation of Crossplane CRDs in make target `dev`

Fixes #104 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

1. Ran `make submodules`
2. Ran `make dev`

[contribution process]: https://git.io/fj2m9
