### PR TITLE
chore: Update OWNERS.md for new maintainers jbw976 and cychiang

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -10,6 +10,11 @@ guidelines and responsibilities for the steering committee and maintainers.
 
 ## Maintainers
 
+* Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
+* Chuan-Yen Chiang <cychiang0823@gmail.com> ([cychiang](https://github.com/cychiang))
+
+## Emeritus Maintainers
+
 * Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
 * Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))
 * Muvaffak Onuş <monus@upbound.io> ([muvaf](https://github.com/muvaf))


### PR DESCRIPTION
### Description of your changes

This PR updates the OWNERS.md file with a new set of maintainers for this repository and moves the existing maintainers to emeritus status. Thank you for your service! 🙇‍♂️ 

This has been discussed already offline with existing maintainer @negz.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

[contribution process]: https://git.io/fj2m9
