### PR TITLE
Inject noop logger by default to ctrl-runtime to avoid warnings

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -74,10 +75,14 @@ func main() {
 	zl := zap.New(zap.UseDevMode(*debug))
 	log := logging.NewLogrLogger(zl.WithName("provider-template"))
 	if *debug {
-		// The controller-runtime runs with a no-op logger by default. It is
-		// *very* verbose even at info level, so we only provide it a real
-		// logger when we're running in debug mode.
+		// The controller-runtime is *very* verbose even at info level, so we only
+		// provide it a real logger when we're running in debug mode.
 		ctrl.SetLogger(zl)
+	} else {
+		// Setting the controller-runtime logger to a no-op logger by default. This
+		// is not really needed, but otherwise we get a warning from the
+		// controller-runtime.
+		ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 	}
 
 	cfg, err := ctrl.GetConfig()


### PR DESCRIPTION
### Description of your changes

controller-runtime [v0.15.0](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.15.0) introduced a warning if the logger is not set for it through crtl.SetLogger.

Except in debug mode, we dont set a logger for it as its too verbose. But as now we get a stack trace warning, adding a noop logger explicity to avoid it.

Fix taken from: https://github.com/crossplane/crossplane/pull/4403

Fixes #105

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.
