### PR TITLE
build: add go.mod.cachedir target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ submodules:
 go.cachedir:
 	@go env GOCACHE
 
+go.mod.cachedir:
+	@go env GOMODCACHE
+
 # NOTE(hasheddan): we must ensure up is installed in tool cache prior to build
 # as including the k8s_tools machinery prior to the xpkg machinery sets UP to
 # point to tool cache.


### PR DESCRIPTION
### Description of your changes

This PR adds a new `go.mod.cachedir` target, which is assumed to exist in the increasingly popular reusable publishing workflow: https://github.com/crossplane-contrib/provider-workflows/blob/main/.github/workflows/publish-provider-non-family.yml#L99-L103

See https://github.com/crossplane-contrib/provider-workflows/issues/13#issuecomment-2936223909 for a bit more details.

Related to https://github.com/crossplane/upjet-provider-template/pull/107

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

```
❯ make go.mod.cachedir
/Users/jared/go/pkg/mod
```

[contribution process]: https://git.io/fj2m9
