### PR TITLE
fix prepare.sh template path

### DIFF
--- a/hack/helpers/prepare.sh
+++ b/hack/helpers/prepare.sh
@@ -37,5 +37,5 @@ sed -i.bak "s/provider-template/provider-${ProviderNameLower}/g" go.mod
 git clean -fd
 
 git mv "apis/template.go" "apis/${ProviderNameLower}.go"
-git mv "internal/controller/template.go" "internal/controller/${ProviderNameLower}.go"
+git mv "internal/controller/register.go" "internal/controller/${ProviderNameLower}.go"
 git mv "cluster/images/provider-template" "cluster/images/provider-${ProviderNameLower}"


### PR DESCRIPTION
### Description of your changes

sets the path in line with changes from https://github.com/crossplane/provider-template/commit/d51e65cbb3570b6f536406c2d6b9365c27a1bc85

Signed-off-by:  Radoslaw 'Goblin' Pieczonka <goblin@pentex.pl>