### PR TITLE
Update helpers template to use group name

### DIFF
--- a/hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains the v1alpha1 group Sample resources of the {{ .Env.PROVIDER }} provider.
+// Package v1alpha1 contains the v1alpha1 group {{ .Env.GROUP }} resources of the {{ .Env.PROVIDER }} provider.
 // +kubebuilder:object:generate=true
 // +groupName={{ .Env.GROUP | strings.ToLower }}.{{ .Env.PROVIDER | strings.ToLower }}.crossplane.io
 // +versionName={{ .Env.APIVERSION | strings.ToLower }}


### PR DESCRIPTION
### Description of your changes

Fix hardcoded Sample in groupversion_info.go.tmpl package comment. Replaced it with {{ .Env.GROUP }} so the generated doc correctly reflects the actual API group name.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.
