### PR TITLE
chore: add jonasz-lasut to maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -12,6 +12,7 @@ guidelines and responsibilities for the steering committee and maintainers.
 
 * Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
 * Chuan-Yen Chiang <cychiang0823@gmail.com> ([cychiang](https://github.com/cychiang))
+* Jonasz Małecki <jonasz@upbound.io> ([@jonasz-lasut](https://github.com/jonasz-lasut))
 
 ## Emeritus Maintainers
 


### PR DESCRIPTION
### Description of your changes

This PR adds @jonasz-lasut to the maintainers list for this repo. He has been very active in the provider-ecosystem recently and his expertise will be valuable in this repository too. I thought of this after seeing his stewardship on https://github.com/crossplane/provider-template/pull/169#issuecomment-5353536986 and the ecosystem PRs leading to that.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Clicking around the links on https://github.com/jbw976/provider-template/blob/jonasz-maintainer/OWNERS.md 

[contribution process]: https://git.io/fj2m9
