### PR TITLE
build: fix test-integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ GOLANGCILINT_VERSION = 2.12.2
 -include build/makelib/golang.mk
 
 # ====================================================================================
+# Setup kind
+KIND_NODE_IMAGE_TAG ?= v1.29.0
+
+# ====================================================================================
 # Setup Kubernetes tools
 
 -include build/makelib/k8s_tools.mk
@@ -56,7 +60,7 @@ fallthrough: submodules
 e2e.run: test-integration
 
 # Run integration tests.
-test-integration: $(KIND) $(KUBECTL) $(CROSSPLANE_CLI) $(HELM3)
+test-integration: $(KIND) $(KUBECTL) $(CROSSPLANE_CLI) $(HELM)
 	@$(INFO) running integration tests using kind $(KIND_VERSION)
 	@KIND_NODE_IMAGE_TAG=${KIND_NODE_IMAGE_TAG} $(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
 	@$(OK) integration tests passed

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -47,13 +47,23 @@ eval $(make --no-print-directory -C ${projectdir} build.vars)
 
 SAFEHOSTARCH="${SAFEHOSTARCH:-amd64}"
 BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${SAFEHOSTARCH}"
-PACKAGE_IMAGE="crossplane.io/inttests/${PROJECT_NAME}:${VERSION}"
-CONTROLLER_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-controller-${SAFEHOSTARCH}"
+CONTROLLER_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${SAFEHOSTARCH}"
 
 version_tag="$(cat ${projectdir}/_output/version)"
 # tag as latest version to load into kind cluster
-PACKAGE_CONTROLLER_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}-controller:${VERSION}"
+PACKAGE_CONTROLLER_IMAGE="${DOCKER_REGISTRY:+${DOCKER_REGISTRY}/}${PROJECT_NAME}-controller:${VERSION}"
 K8S_CLUSTER="${K8S_CLUSTER:-${BUILD_REGISTRY}-inttests}"
+
+# Crossplane v2 requires spec.package to be a fully qualified OCI reference
+# (registry with dots + repo + tag/digest). Use a fake digest so crossplane
+# skips the HEAD request and goes straight to the local cache.
+FAKE_DIGEST="sha256:0000000000000000000000000000000000000000000000000000000000000000"
+PACKAGE_SOURCE="xpkg.crossplane.internal/dev/${PACKAGE_NAME}"
+PACKAGE_IMAGE="${PACKAGE_SOURCE}@${FAKE_DIGEST}"
+# Cache key mirrors crossplane-runtime FriendlyID(source, digest):
+# truncate(source,50) + "-" + truncate(digest,12), DNS-label sanitized.
+PACKAGE_CACHE_ID=$(printf '%.50s-%.12s' "${PACKAGE_SOURCE}" "${FAKE_DIGEST}" \
+  | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | cut -c1-63 | sed 's/-*$//')
 
 CROSSPLANE_NAMESPACE="crossplane-system"
 
@@ -73,8 +83,8 @@ echo_step "setting up local package cache"
 CACHE_PATH="${projectdir}/.work/inttest-package-cache"
 mkdir -p "${CACHE_PATH}"
 echo "created cache dir at ${CACHE_PATH}"
-docker tag "${BUILD_IMAGE}" "${PACKAGE_IMAGE}"
-"${UP}" xpkg xp-extract --from-daemon "${PACKAGE_IMAGE}" -o "${CACHE_PATH}/${PACKAGE_NAME}.gz" && chmod 644 "${CACHE_PATH}/${PACKAGE_NAME}.gz"
+XPKG_PATH="${projectdir}/_output/xpkg/linux_${SAFEHOSTARCH}/${PACKAGE_NAME}-${version_tag}.xpkg"
+"${CROSSPLANE_CLI}" xpkg extract --from-xpkg "${XPKG_PATH}" -o "${CACHE_PATH}/${PACKAGE_CACHE_ID}.gz" && chmod 644 "${CACHE_PATH}/${PACKAGE_CACHE_ID}.gz"
 
 # create kind cluster with extra mounts
 KIND_NODE_IMAGE="kindest/node:${KIND_NODE_IMAGE_TAG}"
@@ -91,9 +101,8 @@ EOF
 )"
 echo "${KIND_CONFIG}" | "${KIND}" create cluster --name="${K8S_CLUSTER}" --wait=5m --image="${KIND_NODE_IMAGE}" --config=-
 
-# tag controller image and load it into kind cluster
-docker tag "${CONTROLLER_IMAGE}" "${PACKAGE_CONTROLLER_IMAGE}"
-"${KIND}" load docker-image "${PACKAGE_CONTROLLER_IMAGE}" --name="${K8S_CLUSTER}"
+# load controller image into kind cluster
+"${KIND}" load docker-image "${CONTROLLER_IMAGE}" --name="${K8S_CLUSTER}"
 
 echo_step "create crossplane-system namespace"
 "${KUBECTL}" create ns crossplane-system
@@ -138,13 +147,13 @@ echo "${PVC_YAML}" | "${KUBECTL}" create -f -
 
 # install crossplane from stable channel
 echo_step "installing crossplane from stable channel"
-"${HELM3}" repo add crossplane-stable https://charts.crossplane.io/stable/
-chart_version="$("${HELM3}" search repo crossplane-stable/crossplane | awk 'FNR == 2 {print $2}')"
+"${HELM}" repo add crossplane-stable https://charts.crossplane.io/stable/ --force-update
+chart_version="$("${HELM}" search repo crossplane-stable/crossplane | awk 'FNR == 2 {print $2}')"
 echo_info "using crossplane version ${chart_version}"
 echo
 # we replace empty dir with our PVC so that the /cache dir in the kind node
 # container is exposed to the crossplane pod
-"${HELM3}" install crossplane --namespace crossplane-system crossplane-stable/crossplane --version ${chart_version} --wait --set packageCache.pvc=package-cache
+"${HELM}" install crossplane --namespace crossplane-system crossplane-stable/crossplane --version ${chart_version} --wait --set packageCache.pvc=package-cache
 
 # ----------- integration tests
 echo_step "--- INTEGRATION TESTS ---"
@@ -153,13 +162,30 @@ echo_step "--- INTEGRATION TESTS ---"
 echo_step "installing ${PROJECT_NAME} into \"${CROSSPLANE_NAMESPACE}\" namespace"
 
 INSTALL_YAML="$( cat <<EOF
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: "${PACKAGE_NAME}"
+spec:
+  deploymentTemplate:
+    spec:
+      selector: {}
+      strategy: {}
+      template:
+        spec:
+          containers:
+          - name: package-runtime
+            image: "${CONTROLLER_IMAGE}"
+---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
   name: "${PACKAGE_NAME}"
 spec:
-  package: "${PACKAGE_NAME}"
+  package: "${PACKAGE_IMAGE}"
   packagePullPolicy: Never
+  runtimeConfigRef:
+    name: "${PACKAGE_NAME}"
 EOF
 )"
 


### PR DESCRIPTION
## Summary

Fixes `make test-integration` which was broken for several reasons accumulated since the script was last tested against the current build system and Crossplane v2.

### Fixes

**Build system mismatches**
- `HELM3` is not exported by the build system (it exports `HELM`); renamed throughout the script and in the Makefile prerequisite — without this, the `helm` binary was never downloaded and the variable was always empty
- `KIND_NODE_IMAGE_TAG ?= v1.29.0` added to the Makefile so the value is defined before being passed to the script via `KIND_NODE_IMAGE_TAG=${KIND_NODE_IMAGE_TAG}`; previously it would expand to empty, causing kind to use `kindest/node:` with no version
- `CONTROLLER_IMAGE` incorrectly included a `-controller-` infix that no image in this repo is built with; corrected to match the actual image name produced by `make build`
- `PACKAGE_CONTROLLER_IMAGE` used `${DOCKER_REGISTRY}/` unconditionally, producing an invalid leading-slash reference when `DOCKER_REGISTRY` is empty; replaced with `${DOCKER_REGISTRY:+${DOCKER_REGISTRY}/}`. The variable is now unused — the controller image is loaded into kind directly under its build name — but kept for potential external use
- `helm repo add` now passes `--force-update` so repeated runs don't fail if the repo is already registered

**Crossplane v2 package cache**
- The old code used `up xpkg xp-extract --from-daemon` on the controller runtime image, which is not a crossplane package — this produced an empty (EOF) cache file. Changed to `crossplane xpkg extract --from-xpkg` against the `.xpkg` file produced by `make build`.
- Crossplane v2 added a CEL validation rule requiring `spec.package` to be a fully qualified OCI reference (`registry.example.com/repo/name:tag` or `@digest`). The previous value `"provider-template"` is rejected. The fix uses the non-routable hostname `xpkg.crossplane.internal` with a zeroed digest (`sha256:0000...`), which passes validation and causes Crossplane to skip the registry `HEAD` request and go straight to the local cache.
- The cache filename is now computed to match crossplane-runtime's `FriendlyID(source, digest)` formula — `truncate(source, 50) + "-" + truncate(digest, 12)`, DNS-label sanitized — so Crossplane can locate the extracted package.

**Controller image for the provider pod**
- `xpkg extract` produces only the package metadata (CRDs, `crossplane.yaml`); it does not preserve the embedded runtime image. Crossplane therefore falls back to using the package OCI reference as the pod image, which does not exist in the kind cluster. A `DeploymentRuntimeConfig` is now created alongside the `Provider` to override the pod image to the locally loaded controller image, following the same pattern used by `build/makelib/local.xpkg.mk`.