### PR TITLE
docs: make the provider bootstrap flow actually work end to end

### DIFF
--- a/PROVIDER_CHECKLIST.md
+++ b/PROVIDER_CHECKLIST.md
@@ -43,18 +43,15 @@ Most Crossplane providers include the following files:
   repository's own [README.md](README.md), or an established provider's like
   [provider-aws/README.md](https://github.com/crossplane-contrib/provider-aws/blob/master/README.md),
   as an example)
-- [ ]  Code is licensed under the [Apache 2.0
-  License](https://github.com/crossplane/provider-template/blob/main/LICENSE)
+- [ ]  Code is licensed under the [Apache 2.0 License](LICENSE)
 - [ ]  Include a “Developer Certificate of Origin”. Example:
   [DCO](https://github.com/crossplane/build/blob/main/DCO)
 - [ ]  Include the CNCF [Code of
   Conduct](https://github.com/crossplane/crossplane/blob/main/CODE_OF_CONDUCT.md)
-- [ ]  Update
-  [OWNERS.md](https://github.com/crossplane/provider-template/blob/main/OWNERS.md)
-  with contacts for project Owners
-- [ ]  Ensure `hack/boilerplate.go.txt` (used in Code generation) includes
-  Crossplane Authors, Apache license and any other Copyright statements:
-  [https://github.com/crossplane/provider-template/blob/main/hack/boilerplate.go.txt](https://github.com/crossplane/provider-template/blob/main/hack/boilerplate.go.txt)
+- [ ]  Update [OWNERS.md](OWNERS.md) with contacts for project Owners
+- [ ]  Ensure [`hack/boilerplate.go.txt`](hack/boilerplate.go.txt) (used in
+  Code generation) includes Crossplane Authors, Apache license and any other
+  Copyright statements
 - [ ] Include Documentation on how to:
   - [ ] Install Provider
   - [ ] Contribute to Development
@@ -82,8 +79,7 @@ repository contains most of these settings.
   [https://github.com/crossplane-contrib/provider-aws/blob/master/.golangci.yml](https://github.com/crossplane-contrib/provider-aws/blob/master/.golangci.yml)
 - [ ] Create a [Crossplane
   Package](https://docs.crossplane.io/latest/packages/)
-  configuration (see
-  [package/crossplane.yaml)](https://github.com/crossplane/provider-template/blob/main/package/crossplane.yaml)
+  configuration (see [package/crossplane.yaml](package/crossplane.yaml))
 
 ## Deployment of Artifacts
 
@@ -97,8 +93,7 @@ the publish and promotion workflows.
 
 In general, providers should:
 
-- [ ] Utilize GitHub workflows from
-  <https://github.com/crossplane/provider-template/tree/main/.github/workflows>
+- [ ] Utilize the [GitHub workflows](.github/workflows) in this repository
 - [ ] Create OCI image repos to push Package and Controller images.
 - [ ] Automatically push Provider images and packages via CI
 - [ ] Add GitHub Secrets to push to Docker repository. (To be performed by
@@ -114,7 +109,7 @@ to grant your project access to the GitHub org scoped secrets.
 
 - [ ] Follow recommendations at
   [https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md#repository-governance](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md#repository-governance)
-- [ ] Enable Issues on your project and configure Issue templates (examples at:
-  [.github/ISSUE_TEMPLATE](https://github.com/crossplane/provider-template/tree/main/.github/ISSUE_TEMPLATE))
-- [ ] Create Pull Request Templates: (example:
-  [PULL_REQUEST_TEMPLATE.md](https://github.com/crossplane/provider-template/blob/main/.github/PULL_REQUEST_TEMPLATE.md))
+- [ ] Enable Issues on your project and configure issue templates (examples
+  at: [.github/ISSUE_TEMPLATE](.github/ISSUE_TEMPLATE))
+- [ ] Create a pull request template (example:
+  [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md))

--- a/PROVIDER_CHECKLIST.md
+++ b/PROVIDER_CHECKLIST.md
@@ -1,7 +1,7 @@
 # Provider Checklist
 
 Crossplane manages Resources external via
-[Providers](https://crossplane.io/docs/master/concepts/providers.html).
+[Providers](https://docs.crossplane.io/latest/packages/providers/).
 Providers are composed of Kubernetes [Custom Resource
 Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)
 and [Controllers](https://kubernetes.io/docs/concepts/architecture/controller)
@@ -9,17 +9,17 @@ that communicate to a remote API and manages the lifecycle of a resource from
 Creation to Deletion.
 
 To build a new provider, please refer to the [Provider Development
-Guide](https://crossplane.io/docs/master/contributing/provider_development_guide.html).
+Guide](https://github.com/crossplane/crossplane/blob/main/contributing/guide-provider-development.md).
 
 This document contains list of items that are usually involved in managing Open
 Source contributions to a Crossplane provider. In general your provider should
 follow the guidelines documented in the [Crossplane
-Contributing](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md)
+Contributing](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md)
 guide.
 
 ## Repository
 
-Although providers can be hosted in any source code repository, the [crossplane-contrib](https://github.com/orgs/crossplane-contrib) Github Organization is available as a neutral home that is under Crossplane's project [governance](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md).
+Although providers can be hosted in any source code repository, the [crossplane-contrib](https://github.com/orgs/crossplane-contrib) Github Organization is available as a neutral home that is under Crossplane's project [governance](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md).
 
 Members of the Crossplane community are happy to create a repository in the *crossplane-contrib* organization and configure access, continuous integration, and storage
 for software artifacts. Please open an issue in the Crossplane
@@ -31,23 +31,24 @@ managed. Example project names are `provider-aws`, `provider-kubernetes`,
 and `provider-github`.
 
 The [provider-template](https://github.com/crossplane/provider-template) repository can be
-used as a starting point for new providers. For [terrajet](https://github.com/crossplane/terrajet)-based providers, the
-[provider-jet-template](https://github.com/crossplane-contrib/provider-jet-template) is
-available.
+used as a starting point for new providers. For Terraform-based providers,
+see [crossplane/upjet](https://github.com/crossplane/upjet), which links to
+its own starter repository.
 
 ## Files
 
 Most Crossplane providers include the following files:
 
-- [ ]  A descriptive README.md at the root of the project (see
-  [provider-gcp/README.md](https://github.com/crossplane/provider-gcp/blob/master/README.md)
+- [ ]  A descriptive README.md at the root of the project (see this
+  repository's own [README.md](README.md), or an established provider's like
+  [provider-aws/README.md](https://github.com/crossplane-contrib/provider-aws/blob/master/README.md),
   as an example)
 - [ ]  Code is licensed under the [Apache 2.0
   License](https://github.com/crossplane/provider-template/blob/main/LICENSE)
 - [ ]  Include a “Developer Certificate of Origin”. Example:
-  [DCO](https://github.com/upbound/build/blob/master/DCO)
+  [DCO](https://github.com/crossplane/build/blob/main/DCO)
 - [ ]  Include the CNCF [Code of
-  Conduct](https://github.com/crossplane/crossplane/blob/master/CODE_OF_CONDUCT.md)
+  Conduct](https://github.com/crossplane/crossplane/blob/main/CODE_OF_CONDUCT.md)
 - [ ]  Update
   [OWNERS.md](https://github.com/crossplane/provider-template/blob/main/OWNERS.md)
   with contacts for project Owners
@@ -71,22 +72,23 @@ across projects.
 The [provider-template](https://github.com/crossplane/provider-template)
 repository contains most of these settings.
 
-- [ ] Use the [Upbound build](https://github.com/upbound/build) submodule. (see
-  [https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#establishing-a-development-environment](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#establishing-a-development-environment))
+- [ ] Use the [crossplane/build](https://github.com/crossplane/build) submodule
+  (this repository already does; see [`.gitmodules`](.gitmodules) and
+  [https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md#establishing-a-development-environment](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md#establishing-a-development-environment)).
 - [ ] Include a
-  [Makefile](https://github.com/crossplane/provider-gcp/blob/master/Makefile)
+  [Makefile](Makefile)
   that supports common build targets.
 - [ ] Use a Golang linter. Example:
-  [https://github.com/crossplane/provider-aws/blob/master/.golangci.yml](https://github.com/crossplane/provider-aws/blob/master/.golangci.yml)
+  [https://github.com/crossplane-contrib/provider-aws/blob/master/.golangci.yml](https://github.com/crossplane-contrib/provider-aws/blob/master/.golangci.yml)
 - [ ] Create a [Crossplane
-  Package](https://crossplane.io/docs/master/concepts/packages.html)
+  Package](https://docs.crossplane.io/latest/packages/)
   configuration (see
   [package/crossplane.yaml)](https://github.com/crossplane/provider-template/blob/main/package/crossplane.yaml)
 
 ## Deployment of Artifacts
 
 When deploying provider artifacts, projects should generally follow the Crossplane
-[release process](https://crossplane.io/docs/master/contributing/release-process.html).
+[release process](https://github.com/crossplane/crossplane/blob/main/RELEASE.md).
 
 Most Crossplane projects use [Github Actions](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) to build, tag, and promote software releases.
 
@@ -105,14 +107,14 @@ In general, providers should:
 If you're part of the crossplane-contrib org and want to enable Github CI, push
 OCI images or packages to the crossplane org in Docker Hub please ask a
 [steering committee
-member](https://github.com/crossplane/crossplane/blob/master/OWNERS.md#steering-committee)
+member](https://github.com/crossplane/crossplane/blob/main/OWNERS.md#steering-committee)
 to grant your project access to the GitHub org scoped secrets.
 
 ## Governance
 
 - [ ] Follow recommendations at
-  [https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md#repository-governance](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md#repository-governance)
+  [https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md#repository-governance](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md#repository-governance)
 - [ ] Enable Issues on your project and configure Issue templates (examples at:
-  [.github/ISSUE_TEMPLATE](https://github.com/crossplane/provider-template/tree/master/.github/ISSUE_TEMPLATE))
+  [.github/ISSUE_TEMPLATE](https://github.com/crossplane/provider-template/tree/main/.github/ISSUE_TEMPLATE))
 - [ ] Create Pull Request Templates: (example:
-  [PULL_REQUEST_TEMPLATE.md](https://github.com/crossplane/provider-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md))
+  [PULL_REQUEST_TEMPLATE.md](https://github.com/crossplane/provider-template/blob/main/.github/PULL_REQUEST_TEMPLATE.md))

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # provider-template
 
 `provider-template` is a minimal [Crossplane](https://crossplane.io/) Provider
-that is meant to be used as a template for implementing new Providers. It comes
-with the following features that are meant to be refactored:
+that is meant to be used as a starting point for implementing new Providers.
+It comes with the following features that are meant to be refactored:
 
 - A `ProviderConfig` type that only points to a credentials `Secret`.
 - A `MyType` resource type that serves as an example managed resource.
@@ -11,25 +11,170 @@ with the following features that are meant to be refactored:
 
 ## Developing
 
-1. Use this repository as a template to create a new one.
-1. Run `make submodules` to initialize the "build" Make submodule we use for CI/CD.
-1. Rename the provider by running the following command:
+The steps below take this repository to a new provider that compiles,
+lints, and passes its tests. They're shown for a provider named `Acme` with
+a `storage` group and a `Bucket` type — substitute your own provider, group,
+and kind throughout.
+
+### Prerequisites
+
+Use the Go toolchain version pinned in [`go.mod`](go.mod) (currently
+`go 1.25.11`). If your local `go version` is newer, pin it before running
+`make reviewable` (step 9):
+
 ```shell
-  export provider_name=MyProvider # Camel case, e.g. GitHub
-  make provider.prepare provider=${provider_name}
+GOTOOLCHAIN=go$(sed -n 's/^go //p' go.mod) make reviewable
 ```
-4. Add your new type by running the following command:
+
+The pinned `golangci-lint` (2.12.2) can't typecheck a newer Go standard
+library, so plain `make reviewable`/`make lint` fails with `could not import
+math/rand/v2 ... (typecheck)` on a newer local Go — even before you touch
+anything in this repo. `go build`/`go test`/`go generate` themselves are
+unaffected; only the lint step needs the pin. Docker is only needed if you
+also want `make build` to produce OCI images.
+
+### 1. Create your repository
+
+Create a new repository based on this one, then clone it:
+
 ```shell
-  export group=sample # lower case e.g. core, cache, database, storage, etc.
-  export type=MyType # Camel casee.g. Bucket, Database, CacheCluster, etc.
-  make provider.addtype provider=${provider_name} group=${group} kind=${type}
+git clone <your-new-repo-url>
+cd <your-new-repo>
 ```
-5. Replace the *sample* group with your new group in apis/{provider}.go
-5. Replace the *mytype* type with your new type in internal/controller/{provider}.go
-5. Replace the default controller and ProviderConfig implementations with your own
-5. Register your new type into `SetupGated` function in `internal/controller/register.go`
-5. Run `make reviewable` to run code generation, linters, and tests.
-5. Run `make build` to build the provider.
+
+### 2. Initialize the build submodule
+
+```shell
+make submodules
+```
+
+### 3. Rename the provider
+
+```shell
+make provider.prepare provider=Acme
+```
+
+> **Warning:** `provider.prepare` runs `git clean -fd`, which deletes
+> **every** untracked file in the repository. Only run it on a clean,
+> freshly cloned tree — before adding any untracked work of your own. It can
+> only be run once; to re-run it, stash or reset your git state first.
+>
+> It also finds-and-replaces this placeholder name (and its capitalized
+> form) with your provider name across nearly every tracked file, including
+> **this README.md, the Makefile, and PROVIDER_CHECKLIST.md themselves**. If
+> you're reading this file from disk rather than from memory, the copy in
+> your clone will read slightly differently from here on.
+
+This moves the API aggregator to `apis/acme.go` and the controller
+aggregator from `internal/controller/register.go` to
+`internal/controller/acme.go`, and deletes the placeholder `apis/sample`,
+`internal/controller/mytype`, and `examples/sample` packages.
+
+**The tree does not compile after this step.** `apis/acme.go` and
+`internal/controller/acme.go` still import the packages that were just
+deleted. Steps 5–6 below fix that — don't run `make generate` or
+`make reviewable` before then; they fail with "not all generators ran
+successfully" while those imports are dangling.
+
+### 4. Add your first API type
+
+```shell
+make provider.addtype provider=Acme group=storage kind=Bucket
+```
+
+Pass `apiversion=v1beta1` (defaults to `v1alpha1`) to generate a different
+API version. This writes:
+
+- `apis/storage/storage.go` and
+  `apis/storage/v1alpha1/{doc,groupversion_info,bucket_types}.go`
+- `internal/controller/bucket/{bucket,bucket_test}.go`
+
+The scaffolded controller is a **no-op stub**: its `Connect`/`Observe`/
+`Create`/`Update`/`Delete` methods don't call any real external API — you
+still need to replace them with calls to your actual backend.
+
+This step does **not** register the new type anywhere, and it does not run
+code generation (`zz_generated.*.go`, `package/crds/**`) — steps 5–9 below
+cover that.
+
+### 5. Register the new type in `apis/acme.go`
+
+```diff
+ import (
+ 	"k8s.io/apimachinery/pkg/runtime"
+
+-	samplev1alpha1 "github.com/crossplane/provider-acme/apis/sample/v1alpha1"
++	storagev1alpha1 "github.com/crossplane/provider-acme/apis/storage/v1alpha1"
+ 	acmev1alpha1 "github.com/crossplane/provider-acme/apis/v1alpha1"
+ )
+
+ func init() {
+ 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
+ 	AddToSchemes = append(AddToSchemes,
+ 		acmev1alpha1.SchemeBuilder.AddToScheme,
+-		samplev1alpha1.SchemeBuilder.AddToScheme,
++		storagev1alpha1.SchemeBuilder.AddToScheme,
+ 	)
+ }
+```
+
+### 6. Register the new controller in `internal/controller/acme.go`
+
+```diff
+ import (
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+ 	ctrl "sigs.k8s.io/controller-runtime"
+
+ 	"github.com/crossplane/provider-acme/internal/controller/config"
+-	"github.com/crossplane/provider-acme/internal/controller/mytype"
++	"github.com/crossplane/provider-acme/internal/controller/bucket"
+ )
+
+ func SetupGated(mgr ctrl.Manager, o controller.Options) error {
+ 	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+ 		config.Setup,
+-		mytype.SetupGated,
++		bucket.SetupGated,
+ 	} {
+ 		if err := setup(mgr, o); err != nil {
+ 			return err
+ 		}
+ 	}
+ 	return nil
+ }
+```
+
+### 7. Add an example manifest
+
+Step 3 deletes `examples/sample/`. Add an example for your new type under
+`examples/storage/`, modeled on the deleted `examples/sample/mytype.yaml` —
+update the `apiVersion` and `kind`, e.g.
+`apiVersion: storage.acme.crossplane.io/v1alpha1` / `kind: Bucket`.
+
+### 8. Format your edits
+
+Hand-editing an import block can misalign it in a way `gofmt` — and
+therefore `make reviewable`'s lint check — rejects:
+
+```shell
+gofmt -w apis/acme.go internal/controller/acme.go
+```
+
+### 9. Verify
+
+```shell
+GOTOOLCHAIN=go$(sed -n 's/^go //p' go.mod) make reviewable
+```
+
+This is the compile-and-lint gate for the branch: it regenerates
+`zz_generated.*.go` and `package/crds/**`, runs `golangci-lint`, and runs the
+unit tests.
+
+From here, `make build` builds the provider binary and, with a Docker daemon
+running, its OCI package and controller images (not re-verified as part of
+the steps above). `make run` runs the provider out-of-cluster for local
+debugging, and `make dev`/`make dev-clean` stand up or tear down a local
+kind cluster to deploy into.
 
 Refer to Crossplane's [CONTRIBUTING.md] file for more information on how the
 Crossplane community prefers to work. The [Provider Development][provider-dev]

--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ make provider.prepare provider=Acme
 >
 > It also finds-and-replaces this placeholder name (and its capitalized
 > form) with your provider name across nearly every tracked file, including
-> **this README.md, the Makefile, and PROVIDER_CHECKLIST.md themselves**. If
-> you're reading this file from disk rather than from memory, the copy in
-> your clone will read slightly differently from here on.
+> **this README.md and the Makefile themselves** (`PROVIDER_CHECKLIST.md` is
+> deliberately exempt — it's a guide about authoring a provider, not about
+> this one). If you're reading this file from disk rather than from memory,
+> the copy in your clone will read slightly differently from here on.
 
 This moves the API aggregator to `apis/acme.go` and the controller
 aggregator from `internal/controller/register.go` to

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ and kind throughout.
 
 ### Prerequisites
 
-Use the Go toolchain version pinned in [`go.mod`](go.mod) (currently
-`go 1.25.11`). If your local `go version` is newer, pin it before running
-`make reviewable` (step 9):
+Use the Go toolchain version pinned in [`go.mod`](go.mod). If your local
+`go version` is newer, pin it before running `make reviewable` (step 9):
 
 ```shell
 GOTOOLCHAIN=go$(sed -n 's/^go //p' go.mod) make reviewable
 ```
 
-The pinned `golangci-lint` (2.12.2) can't typecheck a newer Go standard
-library, so plain `make reviewable`/`make lint` fails with `could not import
+The pinned `golangci-lint` (see `build/makelib/k8s_tools.mk` for the exact
+version) can't typecheck a newer Go standard library, so plain
+`make reviewable`/`make lint` fails with `could not import
 math/rand/v2 ... (typecheck)` on a newer local Go — even before you touch
 anything in this repo. `go build`/`go test`/`go generate` themselves are
 unaffected; only the lint step needs the pin. Docker is only needed if you

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `provider-template` is a minimal [Crossplane](https://crossplane.io/) Provider
 that is meant to be used as a starting point for implementing new Providers.
-It comes with the following features that are meant to be refactored:
+Before you run the steps in [Developing](#developing) below, it ships with:
 
 - A `ProviderConfig` type that only points to a credentials `Secret`.
 - A `MyType` resource type that serves as an example managed resource.
@@ -25,13 +25,13 @@ Use the Go toolchain version pinned in [`go.mod`](go.mod). If your local
 GOTOOLCHAIN=go$(sed -n 's/^go //p' go.mod) make reviewable
 ```
 
-The pinned `golangci-lint` (see `build/makelib/k8s_tools.mk` for the exact
-version) can't typecheck a newer Go standard library, so plain
-`make reviewable`/`make lint` fails with `could not import
-math/rand/v2 ... (typecheck)` on a newer local Go — even before you touch
-anything in this repo. `go build`/`go test`/`go generate` themselves are
-unaffected; only the lint step needs the pin. Docker is only needed if you
-also want `make build` to produce OCI images.
+The pinned `golangci-lint` (its exact version is set in
+`build/makelib/k8s_tools.mk`, added by step 2 below) can't typecheck a newer
+Go standard library, so plain `make reviewable`/`make lint` fails with
+`could not import math/rand/v2 ... (typecheck)` on a newer local Go — even
+before you touch anything in this repo. `go build`/`go test`/`go generate`
+themselves are unaffected; only the lint step needs the pin. Docker is only
+needed if you also want `make build` to produce OCI images.
 
 ### 1. Create your repository
 
@@ -83,15 +83,35 @@ make provider.addtype provider=Acme group=storage kind=Bucket
 ```
 
 Pass `apiversion=v1beta1` (defaults to `v1alpha1`) to generate a different
-API version. This writes:
+API version — the paths below move with it, e.g. `apis/storage/v1beta1/...`
+if you did. This writes:
 
 - `apis/storage/storage.go` and
-  `apis/storage/v1alpha1/{doc,groupversion_info,bucket_types}.go`
+  `apis/storage/<apiversion>/{doc,groupversion_info,bucket_types}.go`
 - `internal/controller/bucket/{bucket,bucket_test}.go`
 
 The scaffolded controller is a **no-op stub**: its `Connect`/`Observe`/
 `Create`/`Update`/`Delete` methods don't call any real external API — you
 still need to replace them with calls to your actual backend.
+
+Unlike `apis/sample/v1alpha1/mytype_types.go`, the generated `bucket_types.go`
+does **not** assert `resource.ModernManaged`/`resource.ManagedList`
+conformance. It can't: that assertion only compiles once
+`zz_generated.managed.go` exists, but `go generate` (step 9) has to
+typecheck this package *before* it can write that file — so a fresh type
+with the assertion already present fails generation with `missing method
+GetCondition` on the very first run. Once step 9 has succeeded at least
+once, you can add the assertion by hand for parity with the sample:
+
+```go
+resource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+
+// interface checks to ensure our types conform to the crossplane-runtime interfaces
+var (
+	_ resource.ModernManaged = &Bucket{}
+	_ resource.ManagedList   = &BucketList{}
+)
+```
 
 This step does **not** register the new type anywhere, and it does not run
 code generation (`zz_generated.*.go`, `package/crds/**`) — steps 5–9 below
@@ -146,10 +166,25 @@ cover that.
 
 ### 7. Add an example manifest
 
-Step 3 deletes `examples/sample/`. Add an example for your new type under
-`examples/storage/`, modeled on the deleted `examples/sample/mytype.yaml` —
-update the `apiVersion` and `kind`, e.g.
-`apiVersion: storage.acme.crossplane.io/v1alpha1` / `kind: Bucket`.
+Step 3 deletes `examples/sample/`. Add `examples/storage/bucket.yaml`:
+
+```yaml
+apiVersion: storage.acme.crossplane.io/v1alpha1
+kind: Bucket
+metadata:
+  name: example
+  namespace: default
+spec:
+  forProvider:
+    configurableField: test
+  providerConfigRef:
+    name: example
+    kind: ProviderConfig
+```
+
+`providerConfigRef.kind` is either `ProviderConfig` (namespaced, shown above)
+or `ClusterProviderConfig`; both are valid because the generated `Bucket`
+type embeds `xpv2.ManagedResourceSpec`, same as `MyType`.
 
 ### 8. Format your edits
 
@@ -180,5 +215,5 @@ Refer to Crossplane's [CONTRIBUTING.md] file for more information on how the
 Crossplane community prefers to work. The [Provider Development][provider-dev]
 guide may also be of use.
 
-[CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md
-[provider-dev]: https://github.com/crossplane/crossplane/blob/master/contributing/guide-provider-development.md
+[CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
+[provider-dev]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-provider-development.md

--- a/hack/helpers/addtype.sh
+++ b/hack/helpers/addtype.sh
@@ -40,5 +40,22 @@ mkdir -p "internal/controller/${kind_lower}"
 ${GOMPLATE} < "hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl" > "internal/controller/${kind_lower}/${kind_lower}.go"
 ${GOMPLATE} < "hack/helpers/controller/KIND_LOWER/KIND_LOWER_test.go.tmpl" > "internal/controller/${kind_lower}/${kind_lower}_test.go"
 
+provider_lower=$(echo "${PROVIDER}" | tr "[:upper:]" "[:lower:]")
 
+cat <<EOF
+
+Next steps (this script only wrote hand-written files; it did not register
+${KIND} anywhere, and it did not run code generation):
+
+  1. In apis/${provider_lower}.go: import "${PROJECT_REPO}/apis/${group_lower}/${APIVERSION}"
+     and add its SchemeBuilder.AddToScheme to AddToSchemes.
+  2. In internal/controller/${provider_lower}.go: import
+     "${PROJECT_REPO}/internal/controller/${kind_lower}" and add
+     ${kind_lower}.SetupGated to the setup list.
+  3. Add an example manifest under examples/${group_lower}/.
+  4. Run: gofmt -w apis/${provider_lower}.go internal/controller/${provider_lower}.go
+  5. Run: make generate && go build ./... && go test ./...
+
+See README.md for the exact before/after edits.
+EOF
 

--- a/hack/helpers/addtype.sh
+++ b/hack/helpers/addtype.sh
@@ -55,6 +55,10 @@ ${KIND} anywhere, and it did not run code generation):
   3. Add an example manifest under examples/${group_lower}/.
   4. Run: gofmt -w apis/${provider_lower}.go internal/controller/${provider_lower}.go
   5. Run: make generate && go build ./... && go test ./...
+  6. (Optional, after step 5 succeeds once) apis/${group_lower}/${APIVERSION}/${kind_lower}_types.go
+     does not assert resource.ModernManaged/resource.ManagedList conformance like
+     apis/sample/v1alpha1/mytype_types.go does — it can't until zz_generated.managed.go
+     exists. Add it by hand now if you want parity with the sample.
 
 See README.md for the exact before/after edits.
 EOF

--- a/hack/helpers/apis/GROUP_LOWER/APIVERSION/KIND_LOWER_types.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/APIVERSION/KIND_LOWER_types.go.tmpl
@@ -22,7 +22,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	resource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+)
+
+// interface checks to ensure our types conform to the crossplane-runtime interfaces
+var (
+	_ resource.ModernManaged = &{{ .Env.KIND }}{}
+	_ resource.ManagedList   = &{{ .Env.KIND }}List{}
 )
 
 // {{ .Env.KIND }}Parameters are the configurable fields of a {{ .Env.KIND }}.

--- a/hack/helpers/apis/GROUP_LOWER/APIVERSION/KIND_LOWER_types.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/APIVERSION/KIND_LOWER_types.go.tmpl
@@ -22,14 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	resource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
-)
-
-// interface checks to ensure our types conform to the crossplane-runtime interfaces
-var (
-	_ resource.ModernManaged = &{{ .Env.KIND }}{}
-	_ resource.ManagedList   = &{{ .Env.KIND }}List{}
 )
 
 // {{ .Env.KIND }}Parameters are the configurable fields of a {{ .Env.KIND }}.

--- a/hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package {{ .Env.APIVERSION | strings.ToLower }} contains the {{ .Env.APIVERSION | strings.ToLower }} group {{ .Env.GROUP | strings.Title }} resources of the {{ .Env.PROVIDER }} provider.
+// Package {{ .Env.APIVERSION | strings.ToLower }} contains the {{ .Env.APIVERSION | strings.ToLower }} group {{ .Env.GROUP | strings.Title }} resources of the {{ .Env.PROVIDER | strings.ToLower }} provider.
 // +kubebuilder:object:generate=true
 // +groupName={{ .Env.GROUP | strings.ToLower }}.{{ .Env.PROVIDER | strings.ToLower }}.crossplane.io
 // +versionName={{ .Env.APIVERSION | strings.ToLower }}

--- a/hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains the v1alpha1 group Sample resources of the {{ .Env.PROVIDER }} provider.
+// Package {{ .Env.APIVERSION | strings.ToLower }} contains the {{ .Env.APIVERSION | strings.ToLower }} group {{ .Env.GROUP | strings.Title }} resources of the {{ .Env.PROVIDER }} provider.
 // +kubebuilder:object:generate=true
 // +groupName={{ .Env.GROUP | strings.ToLower }}.{{ .Env.PROVIDER | strings.ToLower }}.crossplane.io
 // +versionName={{ .Env.APIVERSION | strings.ToLower }}

--- a/hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl
+++ b/hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl
@@ -20,21 +20,22 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
-
-	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	{{ .Env.APIVERSION | strings.ToLower }} "{{ .Env.PROJECT_REPO | strings.ToLower }}/apis/{{ .Env.GROUP | strings.ToLower }}/{{ .Env.APIVERSION | strings.ToLower }}"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+
+	"{{ .Env.PROJECT_REPO | strings.ToLower }}/apis/{{ .Env.GROUP | strings.ToLower }}/{{ .Env.APIVERSION | strings.ToLower }}"
 	apisv1alpha1 "{{ .Env.PROJECT_REPO | strings.ToLower }}/apis/v1alpha1"
 )
 
@@ -50,9 +51,7 @@ const (
 // A NoOpService does nothing.
 type NoOpService struct{}
 
-var (
-	newNoOpService = func(_ []byte) (interface{}, error) { return &NoOpService{}, nil }
-)
+var newNoOpService = func(_ []byte) (interface{}, error) { return &NoOpService{}, nil }
 
 // SetupGated adds a controller that reconciles {{ .Env.KIND }} managed resources with safe-start support.
 func SetupGated(mgr ctrl.Manager, o controller.Options) error {
@@ -60,18 +59,20 @@ func SetupGated(mgr ctrl.Manager, o controller.Options) error {
 		if err := Setup(mgr, o); err != nil {
 			panic(errors.Wrap(err, "cannot setup {{ .Env.KIND }} controller"))
 		}
-	}, v1alpha1.{{ .Env.KIND }}GroupVersionKind)
+	}, {{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}GroupVersionKind)
 	return nil
 }
 
+// Setup adds a controller that reconciles {{ .Env.KIND }} managed resources.
 func Setup(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(v1alpha1.{{ .Env.KIND }}GroupKind)
+	name := managed.ControllerName({{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}GroupKind)
 
 	opts := []managed.ReconcilerOption{
 		managed.WithTypedExternalConnector[*{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}](&connector{
 			kube:         mgr.GetClient(),
 			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-			newServiceFn: newNoOpService}),
+			newServiceFn: newNoOpService,
+		}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))), //nolint:staticcheck // TODO(jbw976) Crossplane needs to update to the new events API, see https://github.com/crossplane/crossplane/issues/7152
@@ -91,20 +92,20 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
-			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.{{ .Env.KIND }}List{}, o.MetricOptions.PollStateMetricInterval,
+			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}List{}, o.MetricOptions.PollStateMetricInterval,
 		)
 		if err := mgr.Add(stateMetricsRecorder); err != nil {
-			return errors.Wrap(err, "cannot register MR state metrics recorder for kind v1alpha1.{{ .Env.KIND }}List")
+			return errors.Wrap(err, "cannot register MR state metrics recorder for kind {{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}List")
 		}
 	}
 
-	r := managed.NewReconciler(mgr, resource.ManagedKind(v1alpha1.{{ .Env.KIND }}GroupVersionKind), opts...)
+	r := managed.NewReconciler(mgr, resource.ManagedKind({{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}GroupVersionKind), opts...)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		WithOptions(o.ForControllerRuntime()).
 		WithEventFilter(resource.DesiredStateChanged()).
-		For(&v1alpha1.{{ .Env.KIND }}{}).
+		For(&{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}{}).
 		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }
 
@@ -146,6 +147,7 @@ func (c *connector) Connect(ctx context.Context, cr *{{ .Env.APIVERSION | string
 	default:
 		return nil, errors.Errorf("unsupported provider config kind: %s", ref.Kind)
 	}
+
 	data, err := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
 	if err != nil {
 		return nil, errors.Wrap(err, errGetCreds)
@@ -168,9 +170,36 @@ type external struct {
 }
 
 func (c *external) Observe(ctx context.Context, cr *{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}) (managed.ExternalObservation, error) {
+	// If the managed resource is marked for deletion then deleted it.
+	// Because there is no external resource to observe, we return false for
+	// ResourceExists.
+	if meta.WasDeleted(cr) {
+		return managed.ExternalObservation{
+			ResourceExists: false,
+		}, nil
+	}
+
 	// These fmt statements should be removed in the real implementation.
 	fmt.Printf("Observing: %+v", cr)
 
+	// Simulate external resource doesn't exist, and enter to create the flow
+	if meta.GetExternalName(cr) == "" {
+		return managed.ExternalObservation{
+			ResourceExists: false,
+		}, nil
+	}
+
+	// Simulate external resource exists and not in sync
+	if cr.Status.AtProvider.ConfigurableField != cr.Spec.ForProvider.ConfigurableField {
+		// This case should trigger an update
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: false,
+		}, nil
+	}
+
+	// Now the resource is in sync and ready to use, so mark it as available.
+	cr.Status.SetConditions(xpv2.Available())
 	return managed.ExternalObservation{
 		// Return false when the external resource does not exist. This lets
 		// the managed resource reconciler know that it needs to call Create to
@@ -189,7 +218,13 @@ func (c *external) Observe(ctx context.Context, cr *{{ .Env.APIVERSION | strings
 }
 
 func (c *external) Create(ctx context.Context, cr *{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}) (managed.ExternalCreation, error) {
+	cr.Status.SetConditions(xpv2.Creating())
+
 	fmt.Printf("Creating: %+v", cr)
+
+	// Copy ConfigurableField to AtProvider and complete the creation.
+	cr.Status.AtProvider.ConfigurableField = cr.Spec.ForProvider.ConfigurableField
+	meta.SetExternalName(cr, "my-external-name")
 
 	return managed.ExternalCreation{
 		// Optionally return any details that may be required to connect to the
@@ -201,6 +236,9 @@ func (c *external) Create(ctx context.Context, cr *{{ .Env.APIVERSION | strings.
 func (c *external) Update(ctx context.Context, cr *{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}) (managed.ExternalUpdate, error) {
 	fmt.Printf("Updating: %+v", cr)
 
+	// Copy ConfigurableField to AtProvider and complete the update.
+	cr.Status.AtProvider.ConfigurableField = cr.Spec.ForProvider.ConfigurableField
+
 	return managed.ExternalUpdate{
 		// Optionally return any details that may be required to connect to the
 		// external resource. These will be stored as the connection secret.
@@ -209,6 +247,8 @@ func (c *external) Update(ctx context.Context, cr *{{ .Env.APIVERSION | strings.
 }
 
 func (c *external) Delete(ctx context.Context, cr *{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}) (managed.ExternalDelete, error) {
+	cr.Status.SetConditions(xpv2.Deleting())
+
 	fmt.Printf("Deleting: %+v", cr)
 
 	return managed.ExternalDelete{}, nil

--- a/hack/helpers/controller/KIND_LOWER/KIND_LOWER_test.go.tmpl
+++ b/hack/helpers/controller/KIND_LOWER/KIND_LOWER_test.go.tmpl
@@ -25,7 +25,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 
-	{{ .Env.APIVERSION | strings.ToLower }} "{{ .Env.PROJECT_REPO | strings.ToLower }}/apis/{{ .Env.GROUP | strings.ToLower }}/{{ .Env.APIVERSION | strings.ToLower }}"
+	"{{ .Env.PROJECT_REPO | strings.ToLower }}/apis/{{ .Env.GROUP | strings.ToLower }}/{{ .Env.APIVERSION | strings.ToLower }}"
 )
 
 // Unlike many Kubernetes projects Crossplane does not use third party testing

--- a/hack/helpers/prepare.sh
+++ b/hack/helpers/prepare.sh
@@ -25,7 +25,7 @@ git rm -r apis/sample
 git rm -r internal/controller/mytype
 git rm -r examples/sample
 
-REPLACE_FILES='./* ./.github :!build/** :!go.* :!hack/**'
+REPLACE_FILES='./* ./.github ./.golangci.yml :!build/** :!go.* :!hack/** :!PROVIDER_CHECKLIST.md'
 # shellcheck disable=SC2086
 git grep -l 'template' -- ${REPLACE_FILES} | xargs sed -i.bak "s/template/${ProviderNameLower}/g"
 # shellcheck disable=SC2086

--- a/hack/helpers/prepare.sh
+++ b/hack/helpers/prepare.sh
@@ -23,6 +23,7 @@ ProviderNameLower=$(echo "${PROVIDER}" | tr "[:upper:]" "[:lower:]")
 
 git rm -r apis/sample
 git rm -r internal/controller/mytype
+git rm -r examples/sample
 
 REPLACE_FILES='./* ./.github :!build/** :!go.* :!hack/**'
 # shellcheck disable=SC2086
@@ -39,3 +40,19 @@ git clean -fd
 git mv "apis/template.go" "apis/${ProviderNameLower}.go"
 git mv "internal/controller/register.go" "internal/controller/${ProviderNameLower}.go"
 git mv "cluster/images/provider-template" "cluster/images/provider-${ProviderNameLower}"
+
+cat <<EOF
+
+Next steps (the tree does not compile yet):
+
+  1. Register your new type's scheme in apis/${ProviderNameLower}.go
+     (replace the apis/sample/v1alpha1 import and its AddToSchemes entry).
+  2. Register your new controller in internal/controller/${ProviderNameLower}.go
+     (replace the internal/controller/mytype import and its SetupGated entry).
+     Run: make provider.addtype provider=${ProviderNameUpper} group=<group> kind=<kind>
+     first if you haven't added a type yet.
+  3. Add an example manifest under examples/<group>/ (examples/sample was removed).
+  4. Run: make generate && go build ./... && go test ./...
+
+See README.md for the exact edits.
+EOF


### PR DESCRIPTION
## Problem

Following `README.md` from this repository did not produce a compiling provider. Replaying the documented steps literally (`provider=Acme group=storage kind=Bucket`) failed, and several of the scaffolding helpers had drifted away from the code they are supposed to mirror.

Verified defects, reproduced before any change was made (an untouched `main` builds, tests, and generates cleanly, so these are real, not environment noise):

- **The tree does not compile after `make provider.prepare`.** `prepare.sh` deletes `apis/sample` and `internal/controller/mytype`, but `apis/<provider>.go` and `internal/controller/<provider>.go` still import them.
- **`go generate ./apis/...` fails for the same reason**, which forces an order the README never stated: prepare → addtype → fix the two aggregators → generate → build. A reader who ran `make reviewable` where the README told them to hit `not all generators ran successfully`.
- **`examples/sample/mytype.yaml` survived `prepare.sh`**, sed-renamed into a manifest referencing a type that had just been deleted.
- **The README pointed at files `prepare.sh` renames** (`internal/controller/register.go`, `apis/template.go`) and was internally inconsistent about them.
- **Ordered-list numbering rendered as `1. 1. 4. 5. 5. 5. 5.`**, and no step mentioned that code generation is required after `addtype`.
- **`hack/helpers/**` templates had drifted** from `apis/sample/**` and `internal/controller/mytype/**`: a hardcoded `Sample` group name, and a controller template still carrying the older no-op stub.
- **`prepare.sh` corrupted `PROVIDER_CHECKLIST.md`.** Seven self-referential URLs became `github.com/crossplane/provider-<name>/...` 404s, and prose was mangled into `configure Issue acmes` / `Create Pull Request Acmes:`.
- **`.golangci.yml` was never renamed.** `REPLACE_FILES` is expanded unquoted, so bash — not git — globs `./*`, and bash's bare `*` does not match dotfiles. Every prepared provider kept `goimports.local-prefixes: github.com/crossplane/provider-template`.
- **`prepare.sh` runs `git clean -fd`** (deletes every untracked file) with no warning anywhere.

## Changes

- `README.md`: the Developing section is now a numbered, runnable walkthrough with exact before/after diffs, the real ordering constraint, the `git clean -fd` warning, a note that the find/replace rewrites the README and Makefile in place, and the Go toolchain pin needed for the pinned `golangci-lint` on a newer local Go.
- `hack/helpers/prepare.sh`: also removes `examples/sample`; excludes `PROVIDER_CHECKLIST.md` from the find/replace (it is a guide about authoring a provider, not a document about your provider); adds `./.golangci.yml` to the pathspec; prints the exact manual registration steps still required.
- `hack/helpers/addtype.sh`: prints the exact registration steps and the code-generation command.
- `hack/helpers/**` templates resynced with the checked-in sample — 5 of 6 files now render byte-identical.
- `PROVIDER_CHECKLIST.md`: stale links fixed (`provider-gcp` archived, terrajet superseded by `crossplane/upjet`, `crossplane.io/docs/master/*` moved to `docs.crossplane.io`, build submodule is `crossplane/build`), and links to files in the reader's own repo made relative.

Scheme and controller registration remain deliberately manual, per the Makefile's existing comment; the scripts now tell you exactly what to do instead of automating it.

### One deliberate divergence

The type template does **not** carry the `resource.ModernManaged` / `resource.ManagedList` conformance assertions that `apis/sample/v1alpha1/mytype_types.go` has. Adding them breaks a genuinely new type: the assertion needs `GetCondition`/`SetConditions`, which only exist once generation writes `zz_generated.managed.go`, but the generators must typecheck the package first. The checked-in sample only works because its generated files already exist on disk. The README documents how to add the block by hand after the first successful `make generate`.

## Verification

Every claim above was reproduced before the change and re-verified after, in throwaway clones, against `main` at 8bb059f (crossplane-runtime v2.4.0).

| Path | Result |
| --- | --- |
| `provider=Acme group=storage kind=Bucket` (default `v1alpha1`) | all 9 README steps pass |
| same, `apiversion=v1beta1` | all 9 README steps pass |

The compile gate in both cases is `make reviewable`: generation OK, `golangci-lint` **0 issues**, all tests pass. Post-change assertions also confirm `.golangci.yml` is correctly rewritten and `PROVIDER_CHECKLIST.md` is left intact.

Independently, a reviewer re-derived the template-sync check (2 of 6 files in sync before → 5 of 6 after) and A/B-verified the interface-assertion divergence, and a separate check followed the rewritten README with no other context and reached a compiling, lint-clean provider on both API-version paths.

## I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

[contribution process]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md

