### PR TITLE
docs: fix drift between docs, and scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ PLATFORMS ?= linux_amd64 linux_arm64
 # ====================================================================================
 # Setup Go
 
+# golangci-lint is a prebuilt binary and cannot typecheck a standard library
+# newer than the Go that built it. GOTOOLCHAIN=auto only upgrades, so pin to
+# go.mod's own directive.
+GOTOOLCHAIN ?= go$(shell sed -n 's/^go //p' go.mod)
+export GOTOOLCHAIN
+
 NPROCS ?= 1
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
@@ -26,6 +32,10 @@ GOLANGCILINT_VERSION = 2.12.2
 # ====================================================================================
 # Setup Kubernetes tools
 
+# The submodule defaults to a 1.x CLI, which drops spec.capabilities when it
+# rebuilds package/crossplane.yaml. The package then installs and reports
+# Healthy but reconciles nothing. Matches crossplane/apis/v2 in go.mod.
+CROSSPLANE_CLI_VERSION ?= v2.3.4
 -include build/makelib/k8s_tools.mk
 
 # ====================================================================================
@@ -128,9 +138,10 @@ export GOMPLATE
 # consider stashing/resetting your git state.
 # Arguments:
 #   provider: Camel case name of your provider, e.g. GitHub, PlanetScale
+#   domain: DNS domain for the API groups. Optional, defaults to "crossplane.io".
 provider.prepare:
 	@[ "${provider}" ] || ( echo "argument \"provider\" is not set"; exit 1 )
-	@PROVIDER=$(provider) ./hack/helpers/prepare.sh
+	@PROVIDER=$(provider) DOMAIN=$(domain) ./hack/helpers/prepare.sh
 
 # This target adds a new api type and its controller.
 # You would still need to register new api in "apis/<provider>.go" and

--- a/PROVIDER_CHECKLIST.md
+++ b/PROVIDER_CHECKLIST.md
@@ -1,7 +1,7 @@
 # Provider Checklist
 
 Crossplane manages Resources external via
-[Providers](https://crossplane.io/docs/master/concepts/providers.html).
+[Providers](https://docs.crossplane.io/latest/packages/providers/).
 Providers are composed of Kubernetes [Custom Resource
 Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)
 and [Controllers](https://kubernetes.io/docs/concepts/architecture/controller)
@@ -9,17 +9,17 @@ that communicate to a remote API and manages the lifecycle of a resource from
 Creation to Deletion.
 
 To build a new provider, please refer to the [Provider Development
-Guide](https://crossplane.io/docs/master/contributing/provider_development_guide.html).
+Guide](https://github.com/crossplane/crossplane/blob/main/contributing/guide-provider-development.md).
 
 This document contains list of items that are usually involved in managing Open
 Source contributions to a Crossplane provider. In general your provider should
 follow the guidelines documented in the [Crossplane
-Contributing](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md)
+Contributing](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md)
 guide.
 
 ## Repository
 
-Although providers can be hosted in any source code repository, the [crossplane-contrib](https://github.com/orgs/crossplane-contrib) Github Organization is available as a neutral home that is under Crossplane's project [governance](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md).
+Although providers can be hosted in any source code repository, the [crossplane-contrib](https://github.com/orgs/crossplane-contrib) Github Organization is available as a neutral home that is under Crossplane's project [governance](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md).
 
 Members of the Crossplane community are happy to create a repository in the *crossplane-contrib* organization and configure access, continuous integration, and storage
 for software artifacts. Please open an issue in the Crossplane
@@ -31,29 +31,27 @@ managed. Example project names are `provider-aws`, `provider-kubernetes`,
 and `provider-github`.
 
 The [provider-template](https://github.com/crossplane/provider-template) repository can be
-used as a starting point for new providers. For [terrajet](https://github.com/crossplane/terrajet)-based providers, the
-[provider-jet-template](https://github.com/crossplane-contrib/provider-jet-template) is
-available.
+used as a starting point for new providers. For Terraform-based providers,
+see [crossplane/upjet](https://github.com/crossplane/upjet), which links to
+its own starter repository.
 
 ## Files
 
 Most Crossplane providers include the following files:
 
-- [ ]  A descriptive README.md at the root of the project (see
-  [provider-gcp/README.md](https://github.com/crossplane/provider-gcp/blob/master/README.md)
+- [ ]  A descriptive README.md at the root of the project (see this
+  repository's own [README.md](README.md), or an established provider's like
+  [provider-aws/README.md](https://github.com/crossplane-contrib/provider-aws/blob/master/README.md),
   as an example)
-- [ ]  Code is licensed under the [Apache 2.0
-  License](https://github.com/crossplane/provider-template/blob/main/LICENSE)
+- [ ]  Code is licensed under the [Apache 2.0 License](LICENSE)
 - [ ]  Include a “Developer Certificate of Origin”. Example:
-  [DCO](https://github.com/upbound/build/blob/master/DCO)
+  [DCO](https://github.com/crossplane/build/blob/main/DCO)
 - [ ]  Include the CNCF [Code of
-  Conduct](https://github.com/crossplane/crossplane/blob/master/CODE_OF_CONDUCT.md)
-- [ ]  Update
-  [OWNERS.md](https://github.com/crossplane/provider-template/blob/main/OWNERS.md)
-  with contacts for project Owners
-- [ ]  Ensure `hack/boilerplate.go.txt` (used in Code generation) includes
-  Crossplane Authors, Apache license and any other Copyright statements:
-  [https://github.com/crossplane/provider-template/blob/main/hack/boilerplate.go.txt](https://github.com/crossplane/provider-template/blob/main/hack/boilerplate.go.txt)
+  Conduct](https://github.com/crossplane/crossplane/blob/main/CODE_OF_CONDUCT.md)
+- [ ]  Update [OWNERS.md](OWNERS.md) with contacts for project Owners
+- [ ]  Ensure [`hack/boilerplate.go.txt`](hack/boilerplate.go.txt) (used in
+  Code generation) includes Crossplane Authors, Apache license and any other
+  Copyright statements
 - [ ] Include Documentation on how to:
   - [ ] Install Provider
   - [ ] Contribute to Development
@@ -71,22 +69,22 @@ across projects.
 The [provider-template](https://github.com/crossplane/provider-template)
 repository contains most of these settings.
 
-- [ ] Use the [Upbound build](https://github.com/upbound/build) submodule. (see
-  [https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#establishing-a-development-environment](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#establishing-a-development-environment))
+- [ ] Use the [crossplane/build](https://github.com/crossplane/build) submodule
+  (this repository already does; see [`.gitmodules`](.gitmodules) and
+  [https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md#establishing-a-development-environment](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md#establishing-a-development-environment)).
 - [ ] Include a
-  [Makefile](https://github.com/crossplane/provider-gcp/blob/master/Makefile)
+  [Makefile](Makefile)
   that supports common build targets.
 - [ ] Use a Golang linter. Example:
-  [https://github.com/crossplane/provider-aws/blob/master/.golangci.yml](https://github.com/crossplane/provider-aws/blob/master/.golangci.yml)
+  [https://github.com/crossplane-contrib/provider-aws/blob/master/.golangci.yml](https://github.com/crossplane-contrib/provider-aws/blob/master/.golangci.yml)
 - [ ] Create a [Crossplane
-  Package](https://crossplane.io/docs/master/concepts/packages.html)
-  configuration (see
-  [package/crossplane.yaml)](https://github.com/crossplane/provider-template/blob/main/package/crossplane.yaml)
+  Package](https://docs.crossplane.io/latest/packages/)
+  configuration (see [package/crossplane.yaml](package/crossplane.yaml))
 
 ## Deployment of Artifacts
 
 When deploying provider artifacts, projects should generally follow the Crossplane
-[release process](https://crossplane.io/docs/master/contributing/release-process.html).
+[release process](https://github.com/crossplane/crossplane/blob/main/RELEASE.md).
 
 Most Crossplane projects use [Github Actions](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) to build, tag, and promote software releases.
 
@@ -95,8 +93,7 @@ the publish and promotion workflows.
 
 In general, providers should:
 
-- [ ] Utilize GitHub workflows from
-  <https://github.com/crossplane/provider-template/tree/main/.github/workflows>
+- [ ] Utilize the [GitHub workflows](.github/workflows) in this repository
 - [ ] Create OCI image repos to push Package and Controller images.
 - [ ] Automatically push Provider images and packages via CI
 - [ ] Add GitHub Secrets to push to Docker repository. (To be performed by
@@ -105,14 +102,14 @@ In general, providers should:
 If you're part of the crossplane-contrib org and want to enable Github CI, push
 OCI images or packages to the crossplane org in Docker Hub please ask a
 [steering committee
-member](https://github.com/crossplane/crossplane/blob/master/OWNERS.md#steering-committee)
+member](https://github.com/crossplane/crossplane/blob/main/OWNERS.md#steering-committee)
 to grant your project access to the GitHub org scoped secrets.
 
 ## Governance
 
 - [ ] Follow recommendations at
-  [https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md#repository-governance](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md#repository-governance)
-- [ ] Enable Issues on your project and configure Issue templates (examples at:
-  [.github/ISSUE_TEMPLATE](https://github.com/crossplane/provider-template/tree/master/.github/ISSUE_TEMPLATE))
-- [ ] Create Pull Request Templates: (example:
-  [PULL_REQUEST_TEMPLATE.md](https://github.com/crossplane/provider-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md))
+  [https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md#repository-governance](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md#repository-governance)
+- [ ] Enable Issues on your project and configure issue templates (examples
+  at: [.github/ISSUE_TEMPLATE](.github/ISSUE_TEMPLATE))
+- [ ] Create a pull request template (example:
+  [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md))

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # provider-template
 
 `provider-template` is a minimal [Crossplane](https://crossplane.io/) Provider
-that is meant to be used as a template for implementing new Providers. It comes
-with the following features that are meant to be refactored:
+that is meant to be used as a starting point for implementing new Providers.
+Before you run the steps in [Developing](#developing) below, it ships with:
 
 - A `ProviderConfig` type that only points to a credentials `Secret`.
 - A `MyType` resource type that serves as an example managed resource.
@@ -11,29 +11,603 @@ with the following features that are meant to be refactored:
 
 ## Developing
 
-1. Use this repository as a template to create a new one.
-1. Run `make submodules` to initialize the "build" Make submodule we use for CI/CD.
-1. Rename the provider by running the following command:
+The steps below take this repository to a new provider that compiles,
+lints, and passes its tests — and, unlike the scaffolded stub, actually does
+something: it manages a Kubernetes `ConfigMap`. They're shown for a provider
+named `Example` with a `config` group and a `ManagedConfigMap` type —
+substitute your own provider, group, and kind throughout.
+
+### Prerequisites
+
+Any recent Go will do — the `Makefile` pins `GOTOOLCHAIN` to [`go.mod`](go.mod)'s
+directive. Don't remove that pin: the bundled `golangci-lint` cannot typecheck a
+standard library newer than the Go that built it, and `make reviewable` then
+fails before you have changed anything.
+
+Docker is only needed if you also want `make build` to produce OCI images.
+
+### 1. Create your repository
+
+Create a new repository based on this one, then clone it:
+
 ```shell
-  export provider_name=MyProvider # Camel case, e.g. GitHub
-  make provider.prepare provider=${provider_name}
+git clone <your-new-repo-url>
+cd <your-new-repo>
 ```
-4. Add your new type by running the following command:
+
+### 2. Initialize the build submodule
+
 ```shell
-  export group=sample # lower case e.g. core, cache, database, storage, etc.
-  export type=MyType # Camel casee.g. Bucket, Database, CacheCluster, etc.
-  make provider.addtype provider=${provider_name} group=${group} kind=${type}
+make submodules
 ```
-5. Replace the *sample* group with your new group in apis/{provider}.go
-5. Replace the *mytype* type with your new type in internal/controller/{provider}.go
-5. Replace the default controller and ProviderConfig implementations with your own
-5. Register your new type into `SetupGated` function in `internal/controller/register.go`
-5. Run `make reviewable` to run code generation, linters, and tests.
-5. Run `make build` to build the provider.
+
+### 3. Rename the provider
+
+```shell
+make provider.prepare provider=Example
+```
+
+> **Warning:** `provider.prepare` runs `git clean -fd`, which deletes
+> **every** untracked file in the repository. Only run it on a clean,
+> freshly cloned tree — before adding any untracked work of your own. It can
+> only be run once; to re-run it, stash or reset your git state first.
+>
+> It also finds-and-replaces this placeholder name (and its capitalized
+> form) with your provider name across nearly every tracked file, including
+> **this README.md and the Makefile themselves** (`PROVIDER_CHECKLIST.md` is
+> deliberately exempt — it's a guide about authoring a provider, not about
+> this one). If you're reading this file from disk rather than from memory,
+> the copy in your clone will read slightly differently from here on.
+
+This moves the API aggregator to `apis/example.go` and the controller
+aggregator from `internal/controller/register.go` to
+`internal/controller/example.go`, and deletes the placeholder `apis/sample`,
+`internal/controller/mytype`, and `examples/sample` packages.
+
+Your API groups default to `example.crossplane.io` (`ProviderConfig`) and
+`<group>.example.crossplane.io` (your types). Pass `domain=` for your own:
+
+```shell
+make provider.prepare provider=Example domain=example.com
+```
+
+Only this provider's groups move — Crossplane's own `meta.pkg.crossplane.io`
+and `crossplane.io/external-name` are left alone. `provider.addtype` takes no
+`domain=`; it reads the suffix back out of `apis/v1alpha1/register.go`.
+
+**The tree does not compile after this step.** `apis/example.go` and
+`internal/controller/example.go` still import the packages that were just
+deleted. Steps 5–6 below fix that — don't run `make generate` or
+`make reviewable` before then; they fail with "not all generators ran
+successfully" while those imports are dangling.
+
+### 4. Add your first API type
+
+```shell
+make provider.addtype provider=Example group=config kind=ManagedConfigMap
+```
+
+Pass `apiversion=v1beta1` (defaults to `v1alpha1`) to generate a different
+API version — the paths below move with it, e.g. `apis/config/v1beta1/...`
+if you did. There is no `domain=` here; step 3 already settled it. This
+writes:
+
+- `apis/config/config.go` and
+  `apis/config/<apiversion>/{doc,groupversion_info,managedconfigmap_types}.go`
+- `internal/controller/managedconfigmap/{managedconfigmap,managedconfigmap_test}.go`
+
+The scaffolded controller is a **no-op stub**: its `Connect`/`Observe`/
+`Create`/`Update`/`Delete` methods don't call any real external API. Step 7
+below replaces it with a real, if simple, implementation that manages a
+`corev1.ConfigMap`.
+
+Unlike `apis/sample/v1alpha1/mytype_types.go`, the generated
+`managedconfigmap_types.go` does **not** assert
+`resource.ModernManaged`/`resource.ManagedList` conformance. It can't: that
+assertion only compiles once `zz_generated.managed.go` exists, but
+`go generate` (step 10) has to typecheck this package *before* it can write
+that file — so a fresh type with the assertion already present fails
+generation with `missing method GetCondition` on the very first run. Once
+step 10 has succeeded at least once, you can add the assertion by hand for
+parity with the sample:
+
+```go
+resource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+
+// interface checks to ensure our types conform to the crossplane-runtime interfaces
+var (
+	_ resource.ModernManaged = &ManagedConfigMap{}
+	_ resource.ManagedList   = &ManagedConfigMapList{}
+)
+```
+
+This step does **not** register the new type anywhere, and it does not run
+code generation (`zz_generated.*.go`, `package/crds/**`) — steps 5–6 below
+register it, and step 10 generates code.
+
+### 5. Register the new type in `apis/example.go`
+
+```diff
+ import (
+ 	"k8s.io/apimachinery/pkg/runtime"
+
+-	samplev1alpha1 "github.com/crossplane/provider-example/apis/sample/v1alpha1"
++	configv1alpha1 "github.com/crossplane/provider-example/apis/config/v1alpha1"
+ 	examplev1alpha1 "github.com/crossplane/provider-example/apis/v1alpha1"
+ )
+
+ func init() {
+ 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
+ 	AddToSchemes = append(AddToSchemes,
+ 		examplev1alpha1.SchemeBuilder.AddToScheme,
+-		samplev1alpha1.SchemeBuilder.AddToScheme,
++		configv1alpha1.SchemeBuilder.AddToScheme,
+ 	)
+ }
+```
+
+On `apiversion=v1beta1`, only the *new* type's import changes: use
+`configv1beta1 "github.com/crossplane/provider-example/apis/config/v1beta1"`.
+`examplev1alpha1` above is this provider's own `apis/v1alpha1` package (the
+`ProviderConfig` types) and stays `v1alpha1` regardless of the managed
+type's API version.
+
+### 6. Register the new controller in `internal/controller/example.go`
+
+```diff
+ import (
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+ 	ctrl "sigs.k8s.io/controller-runtime"
+
+ 	"github.com/crossplane/provider-example/internal/controller/config"
+-	"github.com/crossplane/provider-example/internal/controller/mytype"
++	"github.com/crossplane/provider-example/internal/controller/managedconfigmap"
+ )
+
+ // SetupGated creates all Example controllers with safe-start support and adds them to
+ // the supplied manager.
+ func SetupGated(mgr ctrl.Manager, o controller.Options) error {
+ 	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+ 		config.Setup,
+-		mytype.SetupGated,
++		managedconfigmap.SetupGated,
+ 	} {
+ 		if err := setup(mgr, o); err != nil {
+ 			return err
+ 		}
+ 	}
+ 	return nil
+ }
+```
+
+> `internal/controller/config` above is the built-in `ProviderConfig`
+> controller — unrelated to the `config` API *group* picked in step 4. They
+> only share a name because of this example's naming, not because one
+> depends on the other.
+
+### 7. Implement a real ManagedConfigMap
+
+The scaffolded controller doesn't talk to anything real. Replace it with an
+implementation that manages one `corev1.ConfigMap` per `ManagedConfigMap`,
+in the resource's own namespace, named by its external-name annotation.
+
+**This implementation is real, but deliberately minimal — it doesn't set an
+owner reference or otherwise record that it created the ConfigMap.** In
+practice that means: a pre-existing, unrelated ConfigMap with the same name
+in the same namespace is silently adopted on the first `Observe` (its data
+gets overwritten on the next `Update`), and deleting the `ManagedConfigMap`
+later deletes that ConfigMap even though this provider never created it. A
+production implementation should check for and refuse to adopt resources it
+didn't create — e.g. by tracking a provider-owned label or annotation, or an
+owner reference — before treating a `Get` hit as "this is mine."
+
+The diffs below are shown for the default `apiversion=v1alpha1`. If you
+generated `v1beta1` in step 4, the file paths change accordingly and the
+import alias from step 5 is `configv1beta1`. More importantly, **every**
+`v1alpha1.` type qualifier below becomes `v1beta1.` — not just in function
+signatures, but also the test file's `apis/config/v1alpha1` import and its
+`notYetCreated := &v1alpha1.ManagedConfigMap{}` line. Copying these diffs
+verbatim on a `v1beta1` type compiles with an "undefined: v1alpha1" error;
+search the pasted code for `v1alpha1` and replace every occurrence.
+
+**`apis/config/v1alpha1/managedconfigmap_types.go`** — replace the
+placeholder fields with the ConfigMap's data:
+
+```diff
+ // ManagedConfigMapParameters are the configurable fields of a ManagedConfigMap.
+ type ManagedConfigMapParameters struct {
+-	ConfigurableField string `json:"configurableField"`
++	// Data are the key/value pairs to set on the managed ConfigMap.
++	Data map[string]string `json:"data"`
+ }
+
+ // ManagedConfigMapObservation are the observable fields of a ManagedConfigMap.
+-type ManagedConfigMapObservation struct {
+-	ConfigurableField string `json:"configurableField"`
+-	ObservableField   string `json:"observableField,omitempty"`
+-}
++type ManagedConfigMapObservation struct{}
+```
+
+**`internal/controller/managedconfigmap/managedconfigmap.go`** — the
+imports and error strings:
+
+```diff
+ import (
+ 	"context"
+-	"fmt"
++	"maps"
+
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
++	corev1 "k8s.io/api/core/v1"
++	kerrors "k8s.io/apimachinery/pkg/api/errors"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/types"
+ 	ctrl "sigs.k8s.io/controller-runtime"
+ 	"sigs.k8s.io/controller-runtime/pkg/client"
+```
+
+```diff
+ 	errNewClient = "cannot create new Service"
++
++	errGetConfigMap    = "cannot get ConfigMap"
++	errCreateConfigMap = "cannot create ConfigMap"
++	errUpdateConfigMap = "cannot update ConfigMap"
++	errDeleteConfigMap = "cannot delete ConfigMap"
+ )
+```
+
+Slotting `corev1`, `kerrors`, and `metav1` alphabetically into the existing
+flat `k8s.io`/`sigs.k8s.io` group, rather than giving them a group of their
+own, is the layout `goimports` produces — `goimports` and `gofmt` are the
+two formatters `golangci-lint` (step 10) enforces. It's not the *only*
+grouping that passes lint (a separate group for them passes too), so treat
+this as what running the formatter gives you, not a rule to memorize —
+trust the linter's actual output over guessing at import grouping by hand.
+
+`Connect` hands its own `kube` client straight to `external`, alongside the
+existing (still-unused-for-this-example) credential-fetching plumbing:
+
+```diff
+-	return &external{service: svc}, nil
++	return &external{kube: c.kube, service: svc}, nil
+ }
+
+ // An ExternalClient observes, then either creates, updates, or deletes an
+ // external resource to ensure it reflects the managed resource's desired state.
+ type external struct {
++	// kube is used to manage the ConfigMap this managed resource represents.
++	kube client.Client
++
+ 	// A 'client' used to connect to the external resource API. In practice this
+ 	// would be something like an AWS SDK client.
+ 	service interface{}
+ }
+```
+
+`Observe`, `Create`, `Update`, and `Delete` become real:
+
+```diff
+ func (c *external) Observe(ctx context.Context, cr *v1alpha1.ManagedConfigMap) (managed.ExternalObservation, error) {
+-	// If the managed resource is marked for deletion then deleted it.
+-	// Because there is no external resource to observe, we return false for
+-	// ResourceExists.
+-	if meta.WasDeleted(cr) {
++	// Belt-and-braces: nothing to look up without an external name. In
++	// practice this never fires — see the note below this diff.
++	if meta.GetExternalName(cr) == "" {
+ 		return managed.ExternalObservation{
+ 			ResourceExists: false,
+ 		}, nil
+ 	}
+
+-	// These fmt statements should be removed in the real implementation.
+-	fmt.Printf("Observing: %+v", cr)
+-
+-	// Simulate external resource doesn't exist, and enter to create the flow
+-	if meta.GetExternalName(cr) == "" {
++	cm := &corev1.ConfigMap{}
++	err := c.kube.Get(ctx, types.NamespacedName{Name: meta.GetExternalName(cr), Namespace: cr.GetNamespace()}, cm)
++	if kerrors.IsNotFound(err) {
+ 		return managed.ExternalObservation{
+ 			ResourceExists: false,
+ 		}, nil
+ 	}
++	if err != nil {
++		return managed.ExternalObservation{}, errors.Wrap(err, errGetConfigMap)
++	}
+
+-	// Simulate external resource exists and not in sync
+-	if cr.Status.AtProvider.ConfigurableField != cr.Spec.ForProvider.ConfigurableField {
+-		// This case should trigger an update
+-		return managed.ExternalObservation{
+-			ResourceExists:   true,
+-			ResourceUpToDate: false,
+-		}, nil
++	upToDate := maps.Equal(cm.Data, cr.Spec.ForProvider.Data)
++	if upToDate {
++		// Now the resource is in sync and ready to use, so mark it as available.
++		cr.Status.SetConditions(xpv2.Available())
+ 	}
+
+-	// Now the resource is in sync and ready to use, so mark it as available.
+-	cr.Status.SetConditions(xpv2.Available())
+ 	return managed.ExternalObservation{
+-		// Return false when the external resource does not exist. This lets
+-		// the managed resource reconciler know that it needs to call Create to
+-		// (re)create the resource, or that it has successfully been deleted.
++		// Both "doesn't exist" cases already returned above, so this is
++		// always true by the time execution reaches here.
+ 		ResourceExists: true,
+
+ 		// Return false when the external resource exists, but it not up to date
+ 		// with the desired managed resource state. This lets the managed
+ 		// resource reconciler know that it needs to call Update.
+-		ResourceUpToDate: true,
+-
+-		// Return any details that may be required to connect to the external
+-		// resource. These will be stored as the connection secret.
+-		ConnectionDetails: managed.ConnectionDetails{},
++		ResourceUpToDate: upToDate,
+ 	}, nil
+ }
+
+ func (c *external) Create(ctx context.Context, cr *v1alpha1.ManagedConfigMap) (managed.ExternalCreation, error) {
+ 	cr.Status.SetConditions(xpv2.Creating())
+
+-	fmt.Printf("Creating: %+v", cr)
++	cm := &corev1.ConfigMap{
++		ObjectMeta: metav1.ObjectMeta{
++			Name:      meta.GetExternalName(cr),
++			Namespace: cr.GetNamespace(),
++		},
++		Data: cr.Spec.ForProvider.Data,
++	}
+
+-	// Copy ConfigurableField to AtProvider and complete the creation.
+-	cr.Status.AtProvider.ConfigurableField = cr.Spec.ForProvider.ConfigurableField
+-	meta.SetExternalName(cr, "my-external-name")
++	if err := c.kube.Create(ctx, cm); err != nil {
++		return managed.ExternalCreation{}, errors.Wrap(err, errCreateConfigMap)
++	}
+
+-	return managed.ExternalCreation{
+-		// Optionally return any details that may be required to connect to the
+-		// external resource. These will be stored as the connection secret.
+-		ConnectionDetails: managed.ConnectionDetails{},
+-	}, nil
++	return managed.ExternalCreation{}, nil
+ }
+
+ func (c *external) Update(ctx context.Context, cr *v1alpha1.ManagedConfigMap) (managed.ExternalUpdate, error) {
+-	fmt.Printf("Updating: %+v", cr)
++	cm := &corev1.ConfigMap{}
++	if err := c.kube.Get(ctx, types.NamespacedName{Name: meta.GetExternalName(cr), Namespace: cr.GetNamespace()}, cm); err != nil {
++		return managed.ExternalUpdate{}, errors.Wrap(err, errGetConfigMap)
++	}
+
+-	// Copy ConfigurableField to AtProvider and complete the update.
+-	cr.Status.AtProvider.ConfigurableField = cr.Spec.ForProvider.ConfigurableField
++	cm.Data = cr.Spec.ForProvider.Data
++	if err := c.kube.Update(ctx, cm); err != nil {
++		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateConfigMap)
++	}
+
+-	return managed.ExternalUpdate{
+-		// Optionally return any details that may be required to connect to the
+-		// external resource. These will be stored as the connection secret.
+-		ConnectionDetails: managed.ConnectionDetails{},
+-	}, nil
++	return managed.ExternalUpdate{}, nil
+ }
+
+ func (c *external) Delete(ctx context.Context, cr *v1alpha1.ManagedConfigMap) (managed.ExternalDelete, error) {
+ 	cr.Status.SetConditions(xpv2.Deleting())
+
+-	fmt.Printf("Deleting: %+v", cr)
++	cm := &corev1.ConfigMap{
++		ObjectMeta: metav1.ObjectMeta{
++			Name:      meta.GetExternalName(cr),
++			Namespace: cr.GetNamespace(),
++		},
++	}
+
++	if err := c.kube.Delete(ctx, cm); err != nil && !kerrors.IsNotFound(err) {
++		return managed.ExternalDelete{}, errors.Wrap(err, errDeleteConfigMap)
++	}
++
+ 	return managed.ExternalDelete{}, nil
+ }
+```
+
+> **The stub's `if meta.WasDeleted(cr) { return ResourceExists: false }`
+> early return is deleted, not moved.** In the stub it's harmless — there's
+> no backend to clean up either way. With a real backend, keeping it would
+> make `Observe` report `ResourceExists: false` for a resource that's
+> pending deletion *without `Delete` ever being called*, orphaning the
+> ConfigMap. Of everything in this step, getting this one backwards is a
+> correctness bug, not a style choice.
+
+With a real `Observe`, `Create()` is reachable, unlike in the stub: the
+scaffolded `Observe` decided a resource "didn't exist" purely from whether
+its external-name annotation was empty, and the default `NameAsExternalName`
+initializer sets that annotation before the very first `Observe` ever runs —
+so that branch was dead code, and every resource silently entered through
+`Update()` instead. Here, existence is decided by an actual `Get` against
+the cluster, so a genuinely new resource really does 404 the first time and
+reaches `Create`.
+
+The new `Observe` keeps a lookalike check — `if meta.GetExternalName(cr) ==
+"" { return ResourceExists: false }` — at its top, and by the argument just
+given, that check is *also* dead code for exactly the same reason. It's kept
+anyway, purely so a `Get` is never attempted with an empty name; without it,
+that call would fail with a Kubernetes API validation error rather than a
+clean `ResourceExists: false`. Unlike the deleted `WasDeleted` check, getting
+this one "wrong" (i.e. deleting it) is not a bug — the `Get`'s own error path
+already handles it correctly via `errGetConfigMap` — so treat it as optional
+belt-and-braces, not as load-bearing logic.
+
+One more gap worth knowing about: `Observe` only calls
+`cr.Status.SetConditions(xpv2.Available())` when `upToDate` is true — it
+never explicitly does anything when the ConfigMap has drifted. That's
+harmless in the sense that `ResourceUpToDate: false` still makes the
+reconciler call `Update`, but the `Ready` condition set by a *previous*,
+in-sync `Observe` is left in place until the drift is corrected, so a reader
+watching `status.conditions` can see `Ready: True` for a resource that's
+momentarily out of sync.
+
+**`internal/controller/managedconfigmap/managedconfigmap_test.go`** — the
+scaffolded test builds `external{service: tc.fields.service}` with a keyed
+struct literal, so it still compiles once `external` gains a `kube` field
+too; but it wouldn't exercise anything you just wrote. Update it to build
+`kube` instead, with one case using `test.MockClient`:
+
+```diff
+ import (
+ 	"context"
+ 	"testing"
+
+ 	"github.com/google/go-cmp/cmp"
+
++	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+ 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
++	kerrors "k8s.io/apimachinery/pkg/api/errors"
++	"k8s.io/apimachinery/pkg/runtime/schema"
++	"sigs.k8s.io/controller-runtime/pkg/client"
+
+ 	v1alpha1 "github.com/crossplane/provider-example/apis/config/v1alpha1"
+ )
+```
+
+```diff
+ func TestObserve(t *testing.T) {
+ 	type fields struct {
+-		service interface{}
++		kube client.Client
+ 	}
+
+ 	type args struct {
+```
+
+```diff
+ 		err error
+ 	}
+
++	notYetCreated := &v1alpha1.ManagedConfigMap{}
++	meta.SetExternalName(notYetCreated, "cool-configmap")
++
+ 	cases := map[string]struct {
+ 		reason string
+ 		fields fields
+ 		args   args
+ 		want   want
+ 	}{
+-		// TODO: Add test cases.
++		"DoesNotExist": {
++			reason: "Observe should report ResourceExists: false when the ConfigMap does not exist yet.",
++			fields: fields{
++				kube: &test.MockClient{
++					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "cool-configmap")),
++				},
++			},
++			args: args{
++				cr: notYetCreated,
++			},
++			want: want{
++				o: managed.ExternalObservation{ResourceExists: false},
++			},
++		},
++		// TODO: Add more test cases.
+ 	}
+
+ 	for name, tc := range cases {
+ 		t.Run(name, func(t *testing.T) {
+-			e := external{service: tc.fields.service}
++			e := external{kube: tc.fields.kube}
+ 			got, err := e.Observe(tc.args.ctx, tc.args.cr)
+```
+
+### 8. Add an example manifest
+
+Step 3 deletes `examples/sample/`. Add `examples/config/managedconfigmap.yaml`:
+
+```yaml
+apiVersion: config.example.crossplane.io/v1alpha1
+kind: ManagedConfigMap
+metadata:
+  name: example
+  namespace: default
+spec:
+  forProvider:
+    data:
+      example: test
+  providerConfigRef:
+    name: example
+    kind: ProviderConfig
+```
+
+`providerConfigRef.kind` is either `ProviderConfig` (namespaced, shown above)
+or `ClusterProviderConfig`; both are valid because the generated
+`ManagedConfigMap` type embeds `xpv2.ManagedResourceSpec`, same as `MyType`.
+
+### 9. Format your edits
+
+Hand-editing an import block can misalign it in a way `gofmt` — and
+therefore `make reviewable`'s lint check — rejects:
+
+```shell
+gofmt -w apis/example.go internal/controller/example.go \
+  apis/config/v1alpha1/managedconfigmap_types.go \
+  internal/controller/managedconfigmap/managedconfigmap.go \
+  internal/controller/managedconfigmap/managedconfigmap_test.go
+```
+
+### 10. Verify
+
+```shell
+make reviewable
+```
+
+This is the compile-and-lint gate for the branch: it regenerates
+`zz_generated.*.go` and `package/crds/**`, runs `golangci-lint`, and runs the
+unit tests.
+
+This example needs no extra RBAC to run. Crossplane's RBAC manager already
+grants every provider pod full access to core `configmaps` (along with
+`secrets`, `events`, and `leases`) via a fixed set of rules appended to the
+"system" `ClusterRole` bound to the provider's own `ServiceAccount` —
+see `rulesSystemExtra` in
+[`internal/controller/rbac/provider/roles/roles.go`](https://github.com/crossplane/crossplane/blob/main/internal/controller/rbac/provider/roles/roles.go)
+in the core Crossplane repository. If a future example needs RBAC for some
+other core or third-party resource, note that `package/crossplane.yaml`'s
+`meta.pkg.crossplane.io/v1alpha1` `Provider` kind — from
+`github.com/crossplane/crossplane/apis/v2`, what this template actually
+depends on — has **no** `spec.controller.permissionRequests` field; its
+`ProviderSpec` is just `MetaSpec` inlined, nothing else. That field only
+exists on the `Provider` kind from Crossplane's legacy, pre-v2
+`github.com/crossplane/crossplane` module (same group name, different Go
+module entirely). Adding it here parses as valid YAML but is silently
+dropped when the package is built, so a reader who copies it over by
+name-matching the key would believe they'd granted RBAC they hadn't.
+
+From here, `make build` builds the provider binary and, with a Docker daemon
+running, its OCI package and controller images (not re-verified as part of
+the steps above). `make run` runs the provider out-of-cluster for local
+debugging, and `make dev`/`make dev-clean` stand up or tear down a local
+kind cluster to deploy into.
 
 Refer to Crossplane's [CONTRIBUTING.md] file for more information on how the
 Crossplane community prefers to work. The [Provider Development][provider-dev]
 guide may also be of use.
 
-[CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md
-[provider-dev]: https://github.com/crossplane/crossplane/blob/master/contributing/guide-provider-development.md
+[CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
+[provider-dev]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-provider-development.md

--- a/hack/helpers/addtype.sh
+++ b/hack/helpers/addtype.sh
@@ -19,9 +19,20 @@
 set -euo pipefail
 
 APIVERSION="${APIVERSION:-v1alpha1}"
-echo "Adding type ${KIND} to group ${GROUP} with version ${APIVERSION}"
+
+# Derived from the ProviderConfig group provider.prepare wrote, not passed in,
+# so a type's group cannot disagree with the provider's own.
+GROUP_SUFFIX=$(sed -n 's/^[[:space:]]*Group[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' apis/v1alpha1/register.go | head -1)
+if [ -z "${GROUP_SUFFIX}" ]; then
+	echo "cannot read the provider's API group from apis/v1alpha1/register.go" >&2
+	echo "run 'make provider.prepare provider=<Name>' first" >&2
+	exit 1
+fi
+
+echo "Adding type ${KIND} to group $(echo "${GROUP}" | tr '[:upper:]' '[:lower:]').${GROUP_SUFFIX} with version ${APIVERSION}"
 
 export GROUP
+export GROUP_SUFFIX
 export KIND
 export APIVERSION
 export PROVIDER
@@ -40,5 +51,26 @@ mkdir -p "internal/controller/${kind_lower}"
 ${GOMPLATE} < "hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl" > "internal/controller/${kind_lower}/${kind_lower}.go"
 ${GOMPLATE} < "hack/helpers/controller/KIND_LOWER/KIND_LOWER_test.go.tmpl" > "internal/controller/${kind_lower}/${kind_lower}_test.go"
 
+provider_lower=$(echo "${PROVIDER}" | tr "[:upper:]" "[:lower:]")
 
+cat <<EOF
+
+Next steps (this script only wrote hand-written files; it did not register
+${KIND} anywhere, and it did not run code generation):
+
+  1. In apis/${provider_lower}.go: import "${PROJECT_REPO}/apis/${group_lower}/${APIVERSION}"
+     and add its SchemeBuilder.AddToScheme to AddToSchemes.
+  2. In internal/controller/${provider_lower}.go: import
+     "${PROJECT_REPO}/internal/controller/${kind_lower}" and add
+     ${kind_lower}.SetupGated to the setup list.
+  3. Add an example manifest under examples/${group_lower}/.
+  4. Run: gofmt -w apis/${provider_lower}.go internal/controller/${provider_lower}.go
+  5. Run: make generate && go build ./... && go test ./...
+  6. (Optional, after step 5 succeeds once) apis/${group_lower}/${APIVERSION}/${kind_lower}_types.go
+     does not assert resource.ModernManaged/resource.ManagedList conformance like
+     apis/sample/v1alpha1/mytype_types.go does — it can't until zz_generated.managed.go
+     exists. Add it by hand now if you want parity with the sample.
+
+See README.md for the exact before/after edits.
+EOF
 

--- a/hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains the v1alpha1 group Sample resources of the {{ .Env.PROVIDER }} provider.
+// Package {{ .Env.APIVERSION | strings.ToLower }} contains the {{ .Env.APIVERSION | strings.ToLower }} group {{ .Env.GROUP | strings.Title }} resources of the {{ .Env.PROVIDER | strings.ToLower }} provider.
 // +kubebuilder:object:generate=true
-// +groupName={{ .Env.GROUP | strings.ToLower }}.{{ .Env.PROVIDER | strings.ToLower }}.crossplane.io
+// +groupName={{ .Env.GROUP | strings.ToLower }}.{{ .Env.GROUP_SUFFIX }}
 // +versionName={{ .Env.APIVERSION | strings.ToLower }}
 package {{ .Env.APIVERSION | strings.ToLower }}
 
@@ -27,7 +27,7 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "{{ .Env.GROUP | strings.ToLower }}.{{ .Env.PROVIDER | strings.ToLower }}.crossplane.io"
+	Group   = "{{ .Env.GROUP | strings.ToLower }}.{{ .Env.GROUP_SUFFIX }}"
 	Version = "{{ .Env.APIVERSION | strings.ToLower }}"
 )
 

--- a/hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl
+++ b/hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl
@@ -20,19 +20,20 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
-
-	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 
 	{{ .Env.APIVERSION | strings.ToLower }} "{{ .Env.PROJECT_REPO | strings.ToLower }}/apis/{{ .Env.GROUP | strings.ToLower }}/{{ .Env.APIVERSION | strings.ToLower }}"
 	apisv1alpha1 "{{ .Env.PROJECT_REPO | strings.ToLower }}/apis/v1alpha1"
@@ -50,9 +51,7 @@ const (
 // A NoOpService does nothing.
 type NoOpService struct{}
 
-var (
-	newNoOpService = func(_ []byte) (interface{}, error) { return &NoOpService{}, nil }
-)
+var newNoOpService = func(_ []byte) (interface{}, error) { return &NoOpService{}, nil }
 
 // SetupGated adds a controller that reconciles {{ .Env.KIND }} managed resources with safe-start support.
 func SetupGated(mgr ctrl.Manager, o controller.Options) error {
@@ -60,18 +59,20 @@ func SetupGated(mgr ctrl.Manager, o controller.Options) error {
 		if err := Setup(mgr, o); err != nil {
 			panic(errors.Wrap(err, "cannot setup {{ .Env.KIND }} controller"))
 		}
-	}, v1alpha1.{{ .Env.KIND }}GroupVersionKind)
+	}, {{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}GroupVersionKind)
 	return nil
 }
 
+// Setup adds a controller that reconciles {{ .Env.KIND }} managed resources.
 func Setup(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(v1alpha1.{{ .Env.KIND }}GroupKind)
+	name := managed.ControllerName({{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}GroupKind)
 
 	opts := []managed.ReconcilerOption{
 		managed.WithTypedExternalConnector[*{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}](&connector{
 			kube:         mgr.GetClient(),
 			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-			newServiceFn: newNoOpService}),
+			newServiceFn: newNoOpService,
+		}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))), //nolint:staticcheck // TODO(jbw976) Crossplane needs to update to the new events API, see https://github.com/crossplane/crossplane/issues/7152
@@ -91,20 +92,20 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
-			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.{{ .Env.KIND }}List{}, o.MetricOptions.PollStateMetricInterval,
+			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}List{}, o.MetricOptions.PollStateMetricInterval,
 		)
 		if err := mgr.Add(stateMetricsRecorder); err != nil {
-			return errors.Wrap(err, "cannot register MR state metrics recorder for kind v1alpha1.{{ .Env.KIND }}List")
+			return errors.Wrap(err, "cannot register MR state metrics recorder for kind {{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}List")
 		}
 	}
 
-	r := managed.NewReconciler(mgr, resource.ManagedKind(v1alpha1.{{ .Env.KIND }}GroupVersionKind), opts...)
+	r := managed.NewReconciler(mgr, resource.ManagedKind({{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}GroupVersionKind), opts...)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		WithOptions(o.ForControllerRuntime()).
 		WithEventFilter(resource.DesiredStateChanged()).
-		For(&v1alpha1.{{ .Env.KIND }}{}).
+		For(&{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}{}).
 		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }
 
@@ -146,6 +147,7 @@ func (c *connector) Connect(ctx context.Context, cr *{{ .Env.APIVERSION | string
 	default:
 		return nil, errors.Errorf("unsupported provider config kind: %s", ref.Kind)
 	}
+
 	data, err := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
 	if err != nil {
 		return nil, errors.Wrap(err, errGetCreds)
@@ -168,9 +170,36 @@ type external struct {
 }
 
 func (c *external) Observe(ctx context.Context, cr *{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}) (managed.ExternalObservation, error) {
+	// If the managed resource is marked for deletion then deleted it.
+	// Because there is no external resource to observe, we return false for
+	// ResourceExists.
+	if meta.WasDeleted(cr) {
+		return managed.ExternalObservation{
+			ResourceExists: false,
+		}, nil
+	}
+
 	// These fmt statements should be removed in the real implementation.
 	fmt.Printf("Observing: %+v", cr)
 
+	// Simulate external resource doesn't exist, and enter to create the flow
+	if meta.GetExternalName(cr) == "" {
+		return managed.ExternalObservation{
+			ResourceExists: false,
+		}, nil
+	}
+
+	// Simulate external resource exists and not in sync
+	if cr.Status.AtProvider.ConfigurableField != cr.Spec.ForProvider.ConfigurableField {
+		// This case should trigger an update
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: false,
+		}, nil
+	}
+
+	// Now the resource is in sync and ready to use, so mark it as available.
+	cr.Status.SetConditions(xpv2.Available())
 	return managed.ExternalObservation{
 		// Return false when the external resource does not exist. This lets
 		// the managed resource reconciler know that it needs to call Create to
@@ -189,7 +218,13 @@ func (c *external) Observe(ctx context.Context, cr *{{ .Env.APIVERSION | strings
 }
 
 func (c *external) Create(ctx context.Context, cr *{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}) (managed.ExternalCreation, error) {
+	cr.Status.SetConditions(xpv2.Creating())
+
 	fmt.Printf("Creating: %+v", cr)
+
+	// Copy ConfigurableField to AtProvider and complete the creation.
+	cr.Status.AtProvider.ConfigurableField = cr.Spec.ForProvider.ConfigurableField
+	meta.SetExternalName(cr, "my-external-name")
 
 	return managed.ExternalCreation{
 		// Optionally return any details that may be required to connect to the
@@ -201,6 +236,9 @@ func (c *external) Create(ctx context.Context, cr *{{ .Env.APIVERSION | strings.
 func (c *external) Update(ctx context.Context, cr *{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}) (managed.ExternalUpdate, error) {
 	fmt.Printf("Updating: %+v", cr)
 
+	// Copy ConfigurableField to AtProvider and complete the update.
+	cr.Status.AtProvider.ConfigurableField = cr.Spec.ForProvider.ConfigurableField
+
 	return managed.ExternalUpdate{
 		// Optionally return any details that may be required to connect to the
 		// external resource. These will be stored as the connection secret.
@@ -209,6 +247,8 @@ func (c *external) Update(ctx context.Context, cr *{{ .Env.APIVERSION | strings.
 }
 
 func (c *external) Delete(ctx context.Context, cr *{{ .Env.APIVERSION | strings.ToLower }}.{{ .Env.KIND }}) (managed.ExternalDelete, error) {
+	cr.Status.SetConditions(xpv2.Deleting())
+
 	fmt.Printf("Deleting: %+v", cr)
 
 	return managed.ExternalDelete{}, nil

--- a/hack/helpers/prepare.sh
+++ b/hack/helpers/prepare.sh
@@ -20,11 +20,13 @@ set -euo pipefail
 
 ProviderNameUpper=${PROVIDER}
 ProviderNameLower=$(echo "${PROVIDER}" | tr "[:upper:]" "[:lower:]")
+DOMAIN="${DOMAIN:-crossplane.io}"
 
 git rm -r apis/sample
 git rm -r internal/controller/mytype
+git rm -r examples/sample
 
-REPLACE_FILES='./* ./.github :!build/** :!go.* :!hack/**'
+REPLACE_FILES='./* ./.github ./.golangci.yml :!build/** :!go.* :!hack/** :!PROVIDER_CHECKLIST.md'
 # shellcheck disable=SC2086
 git grep -l 'template' -- ${REPLACE_FILES} | xargs sed -i.bak "s/template/${ProviderNameLower}/g"
 # shellcheck disable=SC2086
@@ -33,9 +35,41 @@ git grep -l 'Template' -- ${REPLACE_FILES} | xargs sed -i.bak "s/Template/${Prov
 # some imported packages under require section.
 sed -i.bak "s/provider-template/provider-${ProviderNameLower}/g" go.mod
 
+# Retarget the API group domain. Match the provider's whole group string, not
+# the bare domain: meta.crossplane.io and crossplane.io/external-name are
+# Crossplane's own.
+if [ "${DOMAIN}" != "crossplane.io" ]; then
+	# shellcheck disable=SC2086
+	group_files=$(git grep -l "${ProviderNameLower}\.crossplane\.io" -- ${REPLACE_FILES} || true)
+	if [ -n "${group_files}" ]; then
+		echo "${group_files}" |
+			xargs sed -i.bak "s/${ProviderNameLower}\.crossplane\.io/${ProviderNameLower}.${DOMAIN}/g"
+	fi
+fi
+
 # Clean up the .bak files created by sed
 git clean -fd
 
 git mv "apis/template.go" "apis/${ProviderNameLower}.go"
 git mv "internal/controller/register.go" "internal/controller/${ProviderNameLower}.go"
 git mv "cluster/images/provider-template" "cluster/images/provider-${ProviderNameLower}"
+
+cat <<EOF
+
+Your API groups are now ${ProviderNameLower}.${DOMAIN} (ProviderConfig) and
+<group>.${ProviderNameLower}.${DOMAIN} (your types). provider.addtype reads that
+suffix back out of apis/v1alpha1/register.go, so it needs no domain of its own.
+
+Next steps (the tree does not compile yet):
+
+  1. Register your new type's scheme in apis/${ProviderNameLower}.go
+     (replace the apis/sample/v1alpha1 import and its AddToSchemes entry).
+  2. Register your new controller in internal/controller/${ProviderNameLower}.go
+     (replace the internal/controller/mytype import and its SetupGated entry).
+     Run: make provider.addtype provider=${ProviderNameUpper} group=<group> kind=<kind>
+     first if you haven't added a type yet.
+  3. Add an example manifest under examples/<group>/ (examples/sample was removed).
+  4. Run: make generate && go build ./... && go test ./...
+
+See README.md for the exact edits.
+EOF

--- a/internal/controller/mytype/mytype.go
+++ b/internal/controller/mytype/mytype.go
@@ -35,7 +35,7 @@ import (
 
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 
-	"github.com/crossplane/provider-template/apis/sample/v1alpha1"
+	v1alpha1 "github.com/crossplane/provider-template/apis/sample/v1alpha1"
 	apisv1alpha1 "github.com/crossplane/provider-template/apis/v1alpha1"
 )
 

--- a/internal/controller/mytype/mytype_test.go
+++ b/internal/controller/mytype/mytype_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 
-	"github.com/crossplane/provider-template/apis/sample/v1alpha1"
+	v1alpha1 "github.com/crossplane/provider-template/apis/sample/v1alpha1"
 )
 
 // Unlike many Kubernetes projects Crossplane does not use third party testing


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

- Close the gate between multiple version, and outdated docs
- Improve helper functions for `addType.sh`, and `prepare.sh`. Fix some issues where not easy to add a type and domain we want

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
